### PR TITLE
chore: add extension method over ControllerBase

### DIFF
--- a/sample/Ardalis.Result.SampleWeb/Extensions/ResultExtensions.cs
+++ b/sample/Ardalis.Result.SampleWeb/Extensions/ResultExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ardalis.Result.SampleWeb.Extensions
+{
+    public static class ResultExtensions
+    {
+
+        public static ActionResult<T> ToActionResult<T>(this ControllerBase controller, Result<T> result)
+        {
+            if (result.Status == ResultStatus.NotFound) return controller.NotFound();
+            if (result.Status == ResultStatus.Invalid)
+            {
+                foreach (var error in result.ValidationErrors)
+                {
+                    controller.ModelState.AddModelError(error.Key, error.Value);
+                }
+                return  controller.BadRequest(controller.ModelState);
+            }
+
+            return controller.Ok(result.Value);
+        }
+        
+    }
+}

--- a/sample/Ardalis.Result.SampleWeb/MyResultActionFilter.cs
+++ b/sample/Ardalis.Result.SampleWeb/MyResultActionFilter.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Ardalis.Result.SampleWeb
+{
+    public class MyResultActionFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            
+            if (!((context.Result as ObjectResult).Value is IResult result)) return;
+
+            if (!(context.Controller is ControllerBase controller)) return;
+
+            if (result.Status == ResultStatus.NotFound)
+                context.Result = controller.NotFound();
+
+            if (result.Status == ResultStatus.Invalid)
+            {
+                foreach (var error in result.ValidationErrors)
+                {
+                    (context.Controller as ControllerBase).ModelState.AddModelError(error.Key, error.Value);
+                }
+
+                context.Result = controller.BadRequest(controller.ModelState);
+            }
+        }
+    }
+}

--- a/sample/Ardalis.Result.SampleWeb/WeatherForecastFeature/WeatherForecastController.cs
+++ b/sample/Ardalis.Result.SampleWeb/WeatherForecastFeature/WeatherForecastController.cs
@@ -25,9 +25,9 @@ namespace Ardalis.Result.SampleWeb.WeatherForecastFeature
 
         [MyResultActionFilter]
         [HttpPost]
-        public IActionResult GetForecast([FromBody]ForecastRequestDto model)
+        public Result<IEnumerable<WeatherForecast>> GetForecast([FromBody]ForecastRequestDto model)
         {
-            return Ok(_weatherService.GetForecast(model));
+            return _weatherService.GetForecast(model);
 //            var result = _weatherService.GetForecast(model);
 //            if (result.Status == ResultStatus.NotFound) return NotFound();
 //            if (result.Status == ResultStatus.Invalid)

--- a/sample/Ardalis.Result.SampleWeb/WeatherForecastFeature/WeatherForecastController.cs
+++ b/sample/Ardalis.Result.SampleWeb/WeatherForecastFeature/WeatherForecastController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Ardalis.Result.SampleWeb.Extensions;
 using Ardalis.Sample.Core;
 using Ardalis.Sample.Core.DTOs;
 using Ardalis.Sample.Core.Model;
@@ -23,20 +24,22 @@ namespace Ardalis.Result.SampleWeb.WeatherForecastFeature
         }
 
         [HttpPost]
-        public ActionResult<IEnumerable<WeatherForecast>> GetForecast([FromBody]ForecastRequestDto model)
+        public ActionResult<IEnumerable<WeatherForecast>> GetForecast(
+            [FromBody]ForecastRequestDto model)
         {
-            var result = _weatherService.GetForecast(model);
-            if (result.Status == ResultStatus.NotFound) return NotFound();
-            if (result.Status == ResultStatus.Invalid)
-            {
-                foreach (var error in result.ValidationErrors)
-                {
-                    ModelState.AddModelError(error.Key, error.Value);
-                }
-                return BadRequest(ModelState);
-            }
-
-            return Ok(result.Value);
+            return this.ToActionResult(_weatherService.GetForecast(model));
+//            var result = _weatherService.GetForecast(model);
+//            if (result.Status == ResultStatus.NotFound) return NotFound();
+//            if (result.Status == ResultStatus.Invalid)
+//            {
+//                foreach (var error in result.ValidationErrors)
+//                {
+//                    ModelState.AddModelError(error.Key, error.Value);
+//                }
+//                return BadRequest(ModelState);
+//            }
+//
+//            return Ok(result.Value);
 
             // TODO: Write a filter or helper so we can make this one line of code
             // Either return _weatherService.GetForecast(model); and use filter

--- a/sample/Ardalis.Result.SampleWeb/WeatherForecastFeature/WeatherForecastController.cs
+++ b/sample/Ardalis.Result.SampleWeb/WeatherForecastFeature/WeatherForecastController.cs
@@ -23,11 +23,11 @@ namespace Ardalis.Result.SampleWeb.WeatherForecastFeature
             _logger = logger;
         }
 
+        [MyResultActionFilter]
         [HttpPost]
-        public ActionResult<IEnumerable<WeatherForecast>> GetForecast(
-            [FromBody]ForecastRequestDto model)
+        public IActionResult GetForecast([FromBody]ForecastRequestDto model)
         {
-            return this.ToActionResult(_weatherService.GetForecast(model));
+            return Ok(_weatherService.GetForecast(model));
 //            var result = _weatherService.GetForecast(model);
 //            if (result.Status == ResultStatus.NotFound) return NotFound();
 //            if (result.Status == ResultStatus.Invalid)

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -3,7 +3,15 @@ using System.Collections.Generic;
 
 namespace Ardalis.Result
 {
-    public class Result<T>
+    public interface IResult
+    {
+        ResultStatus Status { get; }
+        IEnumerable<string> Errors { get; }
+        Dictionary<string, string> ValidationErrors { get; }
+
+    }
+    
+    public class Result<T> : IResult
     {
         public Result(T value)
         {


### PR DESCRIPTION
An extension method added for ControllerBase which takes a Result<T>
and converts that to ActionResult<T>.

@ardalis , I am afraid we cannot use `ActionFilter` since the `Result` property in the context of all filters is of type `IActionResult` so we are losing the `T` type. If you found any other solutions except the extension method over controller I will be more than happy to hear about that too. 

I was also thinking about inheritance over conversion, but in that case, the library won't be general as it requires to reference some asp.net core libs. and it won't have access to the `ModelState` of the controller too.