### PR TITLE
Change ValidationErrors to Dictionary<string, string[]>

### DIFF
--- a/sample/Ardalis.Result.SampleWeb/Ardalis.Result.SampleWeb.csproj
+++ b/sample/Ardalis.Result.SampleWeb/Ardalis.Result.SampleWeb.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.ApiEndpoints" Version="1.0.0" />
-    <PackageReference Include="Ardalis.Result.AspNetCore" Version="2.1.0" />
+    <!--<PackageReference Include="Ardalis.Result.AspNetCore" Version="2.1.0" />-->
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.4.1" />
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Ardalis.Result.AspNetCore\Ardalis.Result.AspNetCore.csproj" />
     <ProjectReference Include="..\Ardalis.Sample.Core\Ardalis.Sample.Core.csproj" />
   </ItemGroup>
 

--- a/sample/Ardalis.Sample.Core/WeatherService.cs
+++ b/sample/Ardalis.Sample.Core/WeatherService.cs
@@ -21,8 +21,8 @@ namespace Ardalis.Sample.Core
             // validate model
             if (model.PostalCode.Length > 10)
             {
-                return Result<IEnumerable<WeatherForecast>>.Invalid(new Dictionary<string, string> { 
-                    { "PostalCode", "PostalCode cannot exceed 10 characters." } 
+                return Result<IEnumerable<WeatherForecast>>.Invalid(new Dictionary<string, string[]> { 
+                    { "PostalCode", new[] { "PostalCode cannot exceed 10 characters." } } 
                 });
             }
 

--- a/src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj
+++ b/src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj
@@ -21,8 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.Result" Version="1.0.0" />
+    <!--<PackageReference Include="Ardalis.Result" Version="1.0.0" />-->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ardalis.Result\Ardalis.Result.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ardalis.Result.AspNetCore/ResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultExtensions.cs
@@ -22,7 +22,10 @@ namespace Ardalis.Result.AspNetCore
             {
                 foreach (var error in result.ValidationErrors)
                 {
-                    controller.ModelState.AddModelError(error.Key, error.Value);
+                    foreach (var errorMessage in error.Value)
+                    {
+                        controller.ModelState.AddModelError(error.Key, errorMessage);
+                    }
                 }
                 return controller.BadRequest(controller.ModelState);
             }

--- a/src/Ardalis.Result.AspNetCore/TranslateResultToActionResultAttribute.cs
+++ b/src/Ardalis.Result.AspNetCore/TranslateResultToActionResultAttribute.cs
@@ -18,7 +18,10 @@ namespace Ardalis.Result.AspNetCore
             {
                 foreach (var error in result.ValidationErrors)
                 {
-                    (context.Controller as ControllerBase).ModelState.AddModelError(error.Key, error.Value);
+                    foreach (var errorMessage in error.Value)
+                    {
+                        (context.Controller as ControllerBase).ModelState.AddModelError(error.Key, errorMessage);
+                    }
                 }
 
                 context.Result = controller.BadRequest(controller.ModelState);

--- a/src/Ardalis.Result/IResult.cs
+++ b/src/Ardalis.Result/IResult.cs
@@ -7,7 +7,7 @@ namespace Ardalis.Result
     {
         ResultStatus Status { get; }
         IEnumerable<string> Errors { get; }
-        Dictionary<string, string> ValidationErrors { get; }
+        Dictionary<string, string[]> ValidationErrors { get; }
         Type ValueType { get; }
         Object GetValue();
     }

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -24,7 +24,7 @@ namespace Ardalis.Result
         }
         public ResultStatus Status { get; } = ResultStatus.Ok;
         public IEnumerable<string> Errors { get; private set; } = new List<string>();
-        public Dictionary<string, string> ValidationErrors { get; private set;} = new Dictionary<string, string>();
+        public Dictionary<string, string[]> ValidationErrors { get; private set;} = new Dictionary<string, string[]>();
 
         public object GetValue()
         {
@@ -41,7 +41,7 @@ namespace Ardalis.Result
             return new Result<T>(ResultStatus.Error) { Errors = errorMessages };
         }
 
-        public static Result<T> Invalid(Dictionary<string, string> validationErrors)
+        public static Result<T> Invalid(Dictionary<string, string[]> validationErrors)
         {
             return new Result<T>(ResultStatus.Invalid) { ValidationErrors = validationErrors };
         }

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -90,17 +90,18 @@ namespace Ardalis.Result.UnitTests
         [Fact]
         public void InitializesStatusToInvalidAndSetsErrorMessagesGivenInvalidFactoryCall()
         {
-            var validationErrors = new Dictionary<string, string>
+            var validationErrors = new Dictionary<string, string[]>
             {
-                { "name", "Name is required"},
-                { "postalCode", "PostalCode cannot exceed 10 characters"}
+                { "name", new[] {"Name is required", "Name cannot exceed 50 characters" } },
+                { "postalCode", new[] { "PostalCode cannot exceed 10 characters" } }
             };
             // TODO: Support duplicates of the same key with multiple errors
             var result = Result<object>.Invalid(validationErrors);
 
             Assert.Equal(ResultStatus.Invalid, result.Status);
-            Assert.Equal("Name is required", result.ValidationErrors.Values.First());
-            Assert.Equal("PostalCode cannot exceed 10 characters", result.ValidationErrors.Values.Last());
+            Assert.Equal("Name is required", result.ValidationErrors.Values.First().First());
+            Assert.Equal("Name cannot exceed 50 characters", result.ValidationErrors.Values.First().Last());
+            Assert.Equal("PostalCode cannot exceed 10 characters", result.ValidationErrors.Values.Last().First());
         }
 
         [Fact]


### PR DESCRIPTION
Hi Steve,

This changes ValidationErrors to allow mutiple errors for the same key.

I wasn't sure how to update the Nuget links, so I have commented out the package references and just added in a project references.  I presume this is something you can check and change?

Thanks

Paul