### PR TITLE
Updated FluentValidation version to the range that is actually supported

### DIFF
--- a/src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
+++ b/src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
@@ -14,7 +14,7 @@
     <PackageTags>result;pattern;web;api;aspnetcore;mvc;FluentValidation;Validation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>Updating icon to remove deprecated PackageIconUrl</PackageReleaseNotes>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <AssemblyName>Ardalis.Result.FluentValidation</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.5.2" />
+    <PackageReference Include="FluentValidation" Version="[7.0.0,9.5.4]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PR 1 of 2 to resolve https://github.com/ardalis/Result/issues/61

This resolves dependency issues with FluentValidation 10.x by only supporting 7.x to 9.x. 7.x is when Fluent validation switched to .NET Standard.