### PR TITLE
Updated FluentValidation dependency to support the latest 10.x version

### DIFF
--- a/src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
+++ b/src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageTags>result;pattern;web;api;aspnetcore;mvc;FluentValidation;Validation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>Updating icon to remove deprecated PackageIconUrl</PackageReleaseNotes>
-    <Version>3.0.1</Version>
+    <Version>4.0.0</Version>
     <AssemblyName>Ardalis.Result.FluentValidation</AssemblyName>
     <PackageIcon>icon.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.5.2" />
+    <PackageReference Include="FluentValidation" Version="10.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PR 2 of 2 for https://github.com/ardalis/Result/issues/61. [PR 1](https://github.com/ardalis/Result/pull/63) should be merged in first.

FluentValidation 10.x had a breaking change that impacted Ardalis.Result.FluentValidation. This enforces a minimum version of 10.x for FluentValidation.