### PR TITLE
reuse ToActionResult in TranslateResultToActionResultAttribute

### DIFF
--- a/src/Ardalis.Result.AspNetCore/ResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultExtensions.cs
@@ -18,7 +18,7 @@ namespace Ardalis.Result.AspNetCore
         /// <returns></returns>
         public static ActionResult<T> ToActionResult<T>(this Result<T> result, ControllerBase controller)
         {
-            return controller.ToActionResult(result);
+            return controller.ToActionResult((IResult)result);
         }
 
         /// <summary>
@@ -31,9 +31,14 @@ namespace Ardalis.Result.AspNetCore
         public static ActionResult<T> ToActionResult<T>(this ControllerBase controller,
             Result<T> result)
         {
+            return controller.ToActionResult((IResult)result);
+        }
+
+        internal static ActionResult ToActionResult(this ControllerBase controller, IResult result)
+        {
             switch (result.Status)
             {
-                case ResultStatus.Ok: return controller.Ok(result.Value);
+                case ResultStatus.Ok: return controller.Ok(result.GetValue());
                 case ResultStatus.NotFound: return controller.NotFound();
                 case ResultStatus.Forbidden: return controller.Forbid();
                 case ResultStatus.Invalid: return BadRequest(controller, result);
@@ -43,7 +48,7 @@ namespace Ardalis.Result.AspNetCore
             }
         }
 
-        private static ActionResult<T> BadRequest<T>(ControllerBase controller, Result<T> result)
+        private static ActionResult BadRequest(ControllerBase controller, IResult result)
         {
             foreach (var error in result.ValidationErrors)
             {
@@ -54,7 +59,7 @@ namespace Ardalis.Result.AspNetCore
             return controller.BadRequest(controller.ModelState);
         }
 
-        private static ActionResult<T> UnprocessableEntity<T>(ControllerBase controller, Result<T> result)
+        private static ActionResult UnprocessableEntity(ControllerBase controller, IResult result)
         {
             var details = new StringBuilder("Next error(s) occured:");
 

--- a/src/Ardalis.Result.AspNetCore/TranslateResultToActionResultAttribute.cs
+++ b/src/Ardalis.Result.AspNetCore/TranslateResultToActionResultAttribute.cs
@@ -11,30 +11,7 @@ namespace Ardalis.Result.AspNetCore
 
             if (!(context.Controller is ControllerBase controller)) return;
 
-            if (result.Status == ResultStatus.NotFound)
-                context.Result = controller.NotFound();
-
-            if (result.Status == ResultStatus.Invalid)
-            {
-                foreach (var error in result.ValidationErrors)
-                {
-                    // TODO: Fix after updating to 3.0.0
-                    (context.Controller as ControllerBase)?.ModelState.AddModelError(error.Identifier, error.ErrorMessage);
-                }
-
-                context.Result = controller.BadRequest(controller.ModelState);
-            }
-
-            if (result.Status == ResultStatus.Unauthorized)
-                context.Result = controller.Unauthorized();
-
-            if (result.Status == ResultStatus.Forbidden)
-                context.Result = controller.Forbid();
-
-            if (result.Status == ResultStatus.Ok)
-            {
-                context.Result = new OkObjectResult(result.GetValue());
-            }
+            context.Result = controller.ToActionResult(result);
         }
     }
 }


### PR DESCRIPTION
Adding of new statuses may require changes in multiple places.
But if we will reuse ToActionResult in TranslateResultToActionResultAttribute
we will minimize places that should be modified just in case of new ResultStatus.

