### PR TITLE
use net50 instead of netcoreapp3.1 in test projects

### DIFF
--- a/sample/Ardalis.Result.Sample.UnitTests/Ardalis.Result.Sample.UnitTests.csproj
+++ b/sample/Ardalis.Result.Sample.UnitTests/Ardalis.Result.Sample.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Ardalis.Result.UnitTests/Ardalis.Result.UnitTests.csproj
+++ b/tests/Ardalis.Result.UnitTests/Ardalis.Result.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
build workflow fails to find netcoreapp3.1 but net5.0 is present.
possbile fixes:
* use net5.0
* install net core hosting bundle