### PR TITLE
Fix README code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ public async Task<ActionResult<CustomerDTO>>(int customerId)
   }
   catch (Exception ex)
   {
-    return return new StatusCodeResult(StatusCodes.Status500InternalServerError);
+    return new StatusCodeResult(StatusCodes.Status500InternalServerError);
   }
 }
 ```


### PR DESCRIPTION
`return` is typed twice which is probably a typo.