### PR TITLE
Add the ability to return an error body with the Result.NotFound() extension

### DIFF
--- a/sample/Ardalis.Result.Sample.Core/Services/PersonService.cs
+++ b/sample/Ardalis.Result.Sample.Core/Services/PersonService.cs
@@ -30,7 +30,7 @@ namespace Ardalis.Result.Sample.Core.Services
         {
             if (!_knownIds.Any(knownId => knownId == id))
             {
-                return Result.NotFound();
+                return Result.NotFound("Person Not Found");
             }
 
             //Pretend removing person

--- a/sample/Ardalis.Result.SampleWeb.FunctionalTests/PersonControllerDelete.cs
+++ b/sample/Ardalis.Result.SampleWeb.FunctionalTests/PersonControllerDelete.cs
@@ -42,6 +42,8 @@ public class PersonControllerDelete : IClassFixture<WebApplicationFactory<Startu
         var response = await SendDeleteRequest(route, 2);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var stringResponse = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Person Not Found", stringResponse);
     }
 
     private async Task<HttpResponseMessage> SendDeleteRequest(string route, int id)

--- a/src/Ardalis.Result.AspNetCore/ResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
 
@@ -64,7 +65,7 @@ namespace Ardalis.Result.AspNetCore
                 case ResultStatus.Ok: return typeof(Result).IsInstanceOfType(result)
                         ? (ActionResult)controller.Ok() 
                         : controller.Ok(result.GetValue());
-                case ResultStatus.NotFound: return controller.NotFound();
+                case ResultStatus.NotFound: return NotFoundEntity(controller, result);
                 case ResultStatus.Unauthorized: return controller.Unauthorized();
                 case ResultStatus.Forbidden: return controller.Forbid();
                 case ResultStatus.Invalid: return BadRequest(controller, result);
@@ -95,6 +96,26 @@ namespace Ardalis.Result.AspNetCore
                 Title = "Something went wrong.",
                 Detail = details.ToString()
             });
+        }
+
+        private static ActionResult NotFoundEntity(ControllerBase controller, IResult result)
+        {
+            var details = new StringBuilder("Next error(s) occured:");
+
+            if (result.Errors.Any())
+            {
+                foreach (var error in result.Errors) details.Append("* ").Append(error).AppendLine();
+
+                return controller.NotFound(new ProblemDetails
+                {
+                    Title = "Resource not found.",
+                    Detail = details.ToString()
+                });
+            }
+            else
+            {
+                return controller.NotFound();
+            }
         }
     }
 }

--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -80,6 +80,17 @@ namespace Ardalis.Result
         }
 
         /// <summary>
+        /// Represents the situation where a service was unable to find a requested resource.
+        /// Error messages may be provided and will be exposed via the Errors property.
+        /// </summary>
+        /// <param name="errorMessages">A list of string error messages.</param>
+        /// <returns>A Result</returns>
+        public static new Result NotFound(params string[] errorMessages)
+        {
+            return new Result(ResultStatus.NotFound) { Errors = errorMessages };
+        }
+
+        /// <summary>
         /// The parameters to the call were correct, but the user does not have permission to perform some action.
         /// See also HTTP 403 Forbidden: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_client_errors
         /// </summary>

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -128,6 +128,17 @@ namespace Ardalis.Result
         }
 
         /// <summary>
+        /// Represents the situation where a service was unable to find a requested resource.
+        /// Error messages may be provided and will be exposed via the Errors property.
+        /// </summary>
+        /// <param name="errorMessages">A list of string error messages.</param>
+        /// <returns>A Result<typeparamref name="T"/></returns>
+        public static Result<T> NotFound(params string[] errorMessages)
+        {
+            return new Result<T>(ResultStatus.NotFound) { Errors = errorMessages };
+        }
+
+        /// <summary>
         /// The parameters to the call were correct, but the user does not have permission to perform some action.
         /// See also HTTP 403 Forbidden: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_client_errors
         /// </summary>

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -143,6 +143,17 @@ public class ResultConstructor
         var result = Result<object>.NotFound();
 
         Assert.Equal(ResultStatus.NotFound, result.Status);
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void InitializesStatusToNotFoundGivenNotFoundFactoryCallWithString()
+    {
+        var errorMessage = "User Not Found";
+        var result = Result<object>.NotFound(errorMessage);
+
+        Assert.Equal(ResultStatus.NotFound, result.Status);
+        Assert.Equal(errorMessage, result.Errors.First());
     }
 
     [Fact]


### PR DESCRIPTION
#95 

Replicated most of the behavior of `.Error()` but also made it so that if no string is provided it continues to use the standard 404 with no body.