### PR TITLE
Working through code coverage from forks

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,0 +1,40 @@
+name: Comment on the Pull Request
+
+# read-write repo token
+# See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on:
+  workflow_run:
+    workflows: [".NET Core"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    # Only comment on the PR if this is a PR event
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+    - name: Get the PR Number artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow_conclusion: ""
+        name: pr-number
+    - name: Read PR Number into GitHub environment variables
+      run: echo "PR_NUMBER=$(cat pr-number.txt)" >> $GITHUB_ENV
+    - name: Confirm the PR Number (Debugging)
+      run: echo $PR_NUMBER
+    - name: Get the code coverage results file
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow_conclusion: ""
+        name: code-coverage-results
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        number: ${{ env.PR_NUMBER }}
+        recreate: true
+        path: code-coverage-results.md

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -45,9 +45,23 @@ jobs:
         format: 'markdown'
         output: 'both'
 
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
+    - name: Upload code coverage results artifact
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
       with:
-        recreate: true
+        name: code-coverage-results
         path: code-coverage-results.md
+    
+    - name: Save the PR number in an artifact
+      if: github.event_name == 'pull_request' && (success() || failure()) 
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: echo $PR_NUMBER > pr-number.txt
+  
+    - name: Upload the PR number
+      uses: actions/upload-artifact@v3
+      if: github.event_name == 'pull_request' &&  (success() || failure())
+      with:
+        name: pr-number
+        path: ./pr-number.txt

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         name: code-coverage-results
         path: code-coverage-results.md
+        retention-days: 1
     
     - name: Save the PR number in an artifact
       if: github.event_name == 'pull_request' && (success() || failure()) 
@@ -65,3 +66,4 @@ jobs:
       with:
         name: pr-number
         path: ./pr-number.txt
+        retention-days: 1


### PR DESCRIPTION
- Moving the PR comment to a `workflow_run` workflow that is designed for having write access, based on guidance from [GitHub Security Lab: Keeping your GitHub Actions and workflows secure Part 1](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Closes #123