### PR TITLE
Moved nuget version back into csproj to fix package publishing issues

### DIFF
--- a/src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj
+++ b/src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj
@@ -8,6 +8,7 @@
     <PackageTags>result pattern web api aspnetcore mvc</PackageTags>
     <PackageReleaseNotes>PRs 92 and 112. Adding support for .NET 7 and ability to improve Swagger/OpenAPI specifications when using the TranslateResultToActionResult attribute.</PackageReleaseNotes>
     <AssemblyName>Ardalis.Result.AspNetCore</AssemblyName>
+    <Version>7.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
+++ b/src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
@@ -8,6 +8,7 @@
     <PackageTags>result;pattern;web;api;aspnetcore;mvc;FluentValidation;Validation</PackageTags>
     <PackageReleaseNotes>PRs 92 and 112. Adding support for .NET 7.</PackageReleaseNotes>
     <AssemblyName>Ardalis.Result.FluentValidation</AssemblyName>
+    <Version>7.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ardalis.Result/Ardalis.Result.csproj
+++ b/src/Ardalis.Result/Ardalis.Result.csproj
@@ -8,6 +8,7 @@
     <PackageTags>result pattern web api aspnetcore mvc</PackageTags>
     <PackageReleaseNotes>PRs 92 and 112. Adding support for .NET 7</PackageReleaseNotes>
     <AssemblyName>Ardalis.Result</AssemblyName>
+    <Version>7.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,6 @@
     <PackageProjectUrl>https://github.com/ardalis/result</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ardalis/result</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>7.0.0</Version>
     <PackageIcon>icon.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
I broke the build with my last change because the CI process for publishing nuget packages expects the <Version> tag [to be in the csproj file](https://github.com/ardalis/Result/actions/runs/4756332307/jobs/8451728258#step:6:16). This change moves it back to the right spot.

I also noticed the publish action that's being used is [no longer maintained by the author](https://github.com/brandedoutcast/publish-nuget) and that it's using `set-output` which is deprecated and will start [failing bulids in June](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) (when Github officially gets rid of it).