### PR TITLE
Updated github actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -11,31 +11,31 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     # Write permission needed to add PR comment
     permissions:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
           dotnet-version: '7.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-      
+
       # See https://josh-ops.com/posts/github-code-coverage/
       # Add coverlet.collector nuget package to test project - 'dotnet add <TestProject.cspoj> package coverlet
     - name: Test
       run: dotnet test --no-restore --verbosity normal --collect:"XPlat Code Coverage" --logger trx --results-directory coverage
-      
+
     - name: Copy Coverage To Predictable Location
       # run: cp coverage/*/coverage.cobertura.xml coverage/coverage.cobertura.xml
       run: find coverage -type f -name coverage.cobertura.xml -exec cp -p {} coverage/coverage.cobertura.xml \;
-      
+
     - name: Code Coverage Summary Report
       uses: irongut/CodeCoverageSummary@v1.3.0
       # uses: joshjohanning/CodeCoverageSummary@v1.0.2
@@ -52,14 +52,14 @@ jobs:
         name: code-coverage-results
         path: code-coverage-results.md
         retention-days: 1
-    
+
     - name: Save the PR number in an artifact
-      if: github.event_name == 'pull_request' && (success() || failure()) 
+      if: github.event_name == 'pull_request' && (success() || failure())
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.number }}
       run: echo $PR_NUMBER > pr-number.txt
-  
+
     - name: Upload the PR number
       uses: actions/upload-artifact@v3
       if: github.event_name == 'pull_request' &&  (success() || failure())

--- a/.github/workflows/publish-result-related.yml
+++ b/.github/workflows/publish-result-related.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
           dotnet-version: '7.x'
     - name: Install dependencies
@@ -21,13 +21,13 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Publish Ardalis.Result.AspNetCore to NuGet
-      uses: brandedoutcast/publish-nuget@v2.5.0
-      with:
-        PROJECT_FILE_PATH: src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      run: |
+        rm -rf nuget/
+        dotnet pack --no-build src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj --output nuget
+        dotnet nuget push nuget/*.nupkg -k '${{ secrets.NUGET_API_KEY }}' --skip-duplicate -s https://api.nuget.org/v3/index.json
 
     - name: Publish Ardalis.Result.FluentValidation to NuGet
-      uses: brandedoutcast/publish-nuget@v2.5.0
-      with:
-        PROJECT_FILE_PATH: src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      run: |
+        rm -rf nuget/
+        dotnet pack --no-build src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj --output nuget
+        dotnet nuget push nuget/*.nupkg -k '${{ secrets.NUGET_API_KEY }}' --skip-duplicate -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-result.yml
+++ b/.github/workflows/publish-result.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
           dotnet-version: '7.x'
     - name: Install dependencies
@@ -20,8 +20,7 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Publish Ardalis.Result to NuGet
-      uses: brandedoutcast/publish-nuget@v2.5.0
-      with:
-        PROJECT_FILE_PATH: src/Ardalis.Result/Ardalis.Result.csproj
-        NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-        
+      run: |
+        rm -rf nuget/
+        dotnet pack --no-build src/Ardalis.Result/Ardalis.Result.csproj --output nuget
+        dotnet nuget push nuget/*.nupkg -k '${{ secrets.NUGET_API_KEY }}' --skip-duplicate -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
I noticed that there are [deprecation warnings](https://github.com/ardalis/Result/actions/runs/4757010978) with some of the action workflows. Additionally, the action that's being used to publish the nuget packages is [no longer maintained](https://github.com/brandedoutcast/publish-nuget#this-repository-is-archived-). This is a problem because that action uses the `set-output` command, which GitHub has deprecated and will be completely removing at the end of May.

These upgrades should clear warnings around a deprecated nodejs version and issuse with using `set-output`.

For the nuget package publishing, I haven't really been able to test the `push` command but I did try to replicate what the old action was doing to publish packages.