### PR TITLE
Publish the release version of the nuget packages

### DIFF
--- a/.github/workflows/publish-result-related.yml
+++ b/.github/workflows/publish-result-related.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Publish Ardalis.Result.AspNetCore to NuGet
       run: |
         rm -rf nuget/
-        dotnet pack --no-build src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj --output nuget
+        dotnet pack --no-build src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj --configuration Release --output nuget
         dotnet nuget push nuget/*.nupkg -k '${{ secrets.NUGET_API_KEY }}' --skip-duplicate -s https://api.nuget.org/v3/index.json
 
     - name: Publish Ardalis.Result.FluentValidation to NuGet
       run: |
         rm -rf nuget/
-        dotnet pack --no-build src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj --output nuget
+        dotnet pack --no-build src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj --configuration Release --output nuget
         dotnet nuget push nuget/*.nupkg -k '${{ secrets.NUGET_API_KEY }}' --skip-duplicate -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish-result.yml
+++ b/.github/workflows/publish-result.yml
@@ -22,5 +22,5 @@ jobs:
     - name: Publish Ardalis.Result to NuGet
       run: |
         rm -rf nuget/
-        dotnet pack --no-build src/Ardalis.Result/Ardalis.Result.csproj --output nuget
+        dotnet pack --no-build src/Ardalis.Result/Ardalis.Result.csproj --configuration Release --output nuget
         dotnet nuget push nuget/*.nupkg -k '${{ secrets.NUGET_API_KEY }}' --skip-duplicate -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Forgot this argument, so the pack command was trying to pack [debug assemblies](https://github.com/ardalis/Result/actions/runs/4757923748/jobs/8455342230#step:6:10). This should probably be it for me an PRs on this repo today 😅

To make sure this actually works, I did this locally:

```bash
dotnet clean
dotnet build --configuration Release
dotnet pack --no-build src/Ardalis.Result/Ardalis.Result.csproj --configuration Release --output nuget
dotnet pack --no-build src/Ardalis.Result.FluentValidation/Ardalis.Result.FluentValidation.csproj --configuration Release --output nuget
dotnet pack --no-build src/Ardalis.Result.AspNetCore/Ardalis.Result.AspNetCore.csproj --configuration Release --output nuget
```

and all the pack commands succeeded. apologies for all the CI noise.