### PR TITLE
Add support for single validation error with Result.Invalid

### DIFF
--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -78,6 +78,16 @@ namespace Ardalis.Result
         }
 
         /// <summary>
+        /// Represents the validation error that prevent the underlying service from completing.
+        /// </summary>
+        /// <param name="validationError">The validation error encountered</param>
+        /// <returns>A Result</returns>
+        public new static Result Invalid(ValidationError validationError)
+        {
+            return new Result(ResultStatus.Invalid) { ValidationErrors = { validationError } };
+        }
+
+        /// <summary>
         /// Represents validation errors that prevent the underlying service from completing.
         /// </summary>
         /// <param name="validationErrors">A list of validation errors encountered</param>

--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -78,7 +78,7 @@ namespace Ardalis.Result
         }
 
         /// <summary>
-        /// Represents the validation error that prevent the underlying service from completing.
+        /// Represents the validation error that prevents the underlying service from completing.
         /// </summary>
         /// <param name="validationError">The validation error encountered</param>
         /// <returns>A Result</returns>

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -112,7 +112,7 @@ namespace Ardalis.Result
         }
 
         /// <summary>
-        /// Represents a validation error that prevent the underlying service from completing.
+        /// Represents a validation error that prevents the underlying service from completing.
         /// </summary>
         /// <param name="validationError">The validation error encountered</param>
         /// <returns>A Result<typeparamref name="T"/></returns>

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -112,6 +112,16 @@ namespace Ardalis.Result
         }
 
         /// <summary>
+        /// Represents a validation error that prevent the underlying service from completing.
+        /// </summary>
+        /// <param name="validationError">The validation error encountered</param>
+        /// <returns>A Result<typeparamref name="T"/></returns>
+        public static Result<T> Invalid(ValidationError validationError)
+        {
+            return new Result<T>(ResultStatus.Invalid) { ValidationErrors = { validationError } };
+        }
+
+        /// <summary>
         /// Represents validation errors that prevent the underlying service from completing.
         /// </summary>
         /// <param name="validationErrors">A list of validation errors encountered</param>

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -208,9 +208,17 @@ public class ResultConstructor
     }
 
     [Fact]
+    public void InitializedIsSuccessFalseForInvalidListFactoryCall()
+    {
+        var result = Result<object>.Invalid(new List<ValidationError>());
+
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
     public void InitializedIsSuccessFalseForInvalidFactoryCall()
     {
-        var result = Result<object>.Invalid(null);
+        var result = Result<object>.Invalid(new ValidationError());
 
         Assert.False(result.IsSuccess);
     }

--- a/tests/Ardalis.Result.UnitTests/ResultVoidConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidConstructor.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -73,7 +72,7 @@ public class ResultVoidConstructor
     }
 
     [Fact]
-    public void InitializesInvalidResultWithFactoryMethod()
+    public void InitializesInvalidResultWithMultipleValidationErrorsWithFactoryMethod()
     {
         var validationErrors = new List<ValidationError>
             {
@@ -96,6 +95,23 @@ public class ResultVoidConstructor
 
         result.ValidationErrors.Should().ContainEquivalentOf(new ValidationError { ErrorMessage = "Name is required", Identifier = "name" });
         result.ValidationErrors.Should().ContainEquivalentOf(new ValidationError { ErrorMessage = "PostalCode cannot exceed 10 characters", Identifier = "postalCode" });
+    }
+
+    [Fact]
+    public void InitializesInvalidResultWithSingleValidationErrorWithFactoryMethod()
+    {
+        var validationError = new ValidationError
+        {
+            Identifier = "name",
+            ErrorMessage = "Name is required"
+        };
+
+        var result = Result.Invalid(validationError);
+
+        Assert.Null(result.Value);
+        Assert.Equal(ResultStatus.Invalid, result.Status);
+
+        result.ValidationErrors.Should().ContainEquivalentOf(new ValidationError { ErrorMessage = "Name is required", Identifier = "name" });
     }
 
     [Fact]

--- a/tests/Ardalis.Result.UnitTests/ResultVoidMap.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidMap.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Ardalis.Result.UnitTests
@@ -49,9 +50,20 @@ namespace Ardalis.Result.UnitTests
         }
 
         [Fact]
+        public void ShouldProduceInvalidWithEmptyList()
+        {
+            var result = Result.Invalid(new List<ValidationError>());
+
+            var actual = result.Map(_ => "This should be ignored");
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
         public void ShouldProduceInvalid()
         {
-            var result = Result.Invalid(new());
+            var result = Result.Invalid(new ValidationError());
 
             var actual = result.Map(_ => "This should be ignored");
 

--- a/tests/Ardalis.Result.UnitTests/ResultVoidToResultOfT.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidToResultOfT.cs
@@ -23,7 +23,7 @@ public class ResultVoidToResultOfT
     }
 
     [Fact]
-    public void ConvertFromInvalidResultOfUnit()
+    public void ConvertFromInvalidResultOfUnitWithValidationErrorList()
     {
         var validationErrors = new List<ValidationError>
             {
@@ -47,6 +47,24 @@ public class ResultVoidToResultOfT
         result.Status.Should().Be(ResultStatus.Invalid);
         result.ValidationErrors.Should().ContainEquivalentOf(new ValidationError { ErrorMessage = "Name is required", Identifier = "name" });
         result.ValidationErrors.Should().ContainEquivalentOf(new ValidationError { ErrorMessage = "PostalCode cannot exceed 10 characters", Identifier = "postalCode" });
+    }
+
+    [Fact]
+    public void ConvertFromInvalidResultOfUnitWithValidationError()
+    {
+        var validationError = new ValidationError
+        {
+            Identifier = "name",
+            ErrorMessage = "Name is required"
+        };
+
+        var result = DoBusinessOperationExample<object>(Result.Invalid(validationError));
+
+        Assert.Null(result.Value);
+        Assert.Equal(ResultStatus.Invalid, result.Status);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainEquivalentOf(new ValidationError { ErrorMessage = "Name is required", Identifier = "name" });
     }
 
     [Fact]


### PR DESCRIPTION
More often than not I find myself passing a single Validation error in the Result.Invalid method. This PR addresses that. 
I do believe this to be a needed improvement, as it's very annoying to create new Lists only to pass a single object in them.  


- Support for single validation error in the Result.Invalid method
- Added unit tests to validate behavior 
- All existing behavior remains the same. The single instance of the Validation Error will be passed in a new List<ValdiationError> upon Result.Invalid creation 
```
     //This instantiates a new list with the single validation error in it
     public new static Result Invalid(ValidationError validationError)
        {
            return new Result(ResultStatus.Invalid) { ValidationErrors = { validationError } };
        }
```