### PR TITLE
Add Unavailable result status

### DIFF
--- a/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
@@ -134,7 +134,6 @@ public static partial class ResultExtensions
                 Title = "Service unavailable.",
                 Detail = details.ToString(),
                 Status = StatusCodes.Status503ServiceUnavailable
-                ream/main
             });
         }
         else

--- a/src/Ardalis.Result.AspNetCore/ResultStatusMap.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultStatusMap.cs
@@ -38,7 +38,10 @@ namespace Ardalis.Result.AspNetCore
                     .With(ConflictEntity))
                 .For(ResultStatus.CriticalError, HttpStatusCode.InternalServerError, resultStatusOptions =>
                     resultStatusOptions
-                        .With(CriticalEntity));
+                        .With(CriticalEntity))
+                .For(ResultStatus.Unavailable, HttpStatusCode.ServiceUnavailable, resultStatusOptions =>
+                    resultStatusOptions
+                        .With(UnavailableEntity));
         }
 
         /// <summary>
@@ -152,6 +155,19 @@ namespace Ardalis.Result.AspNetCore
             return new ProblemDetails
             {
                 Title = "Something went wrong.",
+                Detail = result.Errors.Any() ? details.ToString() : null
+            };
+        }
+
+        private static ProblemDetails UnavailableEntity(ControllerBase controller, IResult result)
+        {
+            var details = new StringBuilder("Next error(s) occured:");
+
+            foreach (var error in result.Errors) details.Append("* ").Append(error).AppendLine();
+
+            return new ProblemDetails
+            {
+                Title = "Service is unavailable.",
                 Detail = result.Errors.Any() ? details.ToString() : null
             };
         }

--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -160,5 +160,17 @@ namespace Ardalis.Result
         {
             return new Result(ResultStatus.Conflict) { Errors = errorMessages };
         }
+
+        /// <summary>
+        /// Represents a situation where a service is unavailable, such as when the underlying data store is unavailable.
+        /// Errors may be transient, so the caller may wish to retry the operation.
+        /// See also HTTP 503 Service Unavailable: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
+        /// </summary>
+        /// <param name="errorMessages">A list of string error messages</param>
+        /// <returns></returns>
+        public new static Result Unavailable(params string[] errorMessages)
+        {
+            return new Result(ResultStatus.Unavailable) { Errors = errorMessages };
+        }
     }
 }

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -206,5 +206,17 @@ namespace Ardalis.Result
         {
             return new Result<T>(ResultStatus.CriticalError) { Errors = errorMessages };
         }
+
+        /// <summary>
+        /// Represents a situation where a service is unavailable, such as when the underlying data store is unavailable.
+        /// Errors may be transient, so the caller may wish to retry the operation.
+        /// See also HTTP 503 Service Unavailable: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
+        /// </summary>
+        /// <param name="errorMessages">A list of string error messages</param>
+        /// <returns></returns>
+        public static Result<T> Unavailable(params string[] errorMessages)
+        {
+            return new Result<T>(ResultStatus.Unavailable) { Errors = errorMessages};
+        }
     }
 }

--- a/src/Ardalis.Result/ResultExtensions.cs
+++ b/src/Ardalis.Result/ResultExtensions.cs
@@ -30,6 +30,7 @@ namespace Ardalis.Result
                                         ? Result<TDestination>.Conflict(result.Errors.ToArray())
                                         : Result<TDestination>.Conflict();
                 case ResultStatus.CriticalError: return Result<TDestination>.CriticalError(result.Errors.ToArray());
+                case ResultStatus.Unavailable: return Result<TDestination>.Unavailable(result.Errors.ToArray());
                 default:
                     throw new NotSupportedException($"Result {result.Status} conversion is not supported.");
             }

--- a/src/Ardalis.Result/ResultStatus.cs
+++ b/src/Ardalis.Result/ResultStatus.cs
@@ -9,6 +9,7 @@
         Invalid,
         NotFound,
         Conflict,
-        CriticalError
+        CriticalError,
+        Unavailable
     }
 }

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMap.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMap.cs
@@ -18,7 +18,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -28,6 +28,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 
     [Fact]
@@ -42,7 +43,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -52,6 +53,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 
     [Fact]
@@ -81,7 +83,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -91,6 +93,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 
     [Theory]
@@ -107,7 +110,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 200, expectedType));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -117,5 +120,6 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 }

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMapModified.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMapModified.cs
@@ -21,7 +21,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(6, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(7, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -29,6 +29,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 
     [Fact]
@@ -45,7 +46,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(7, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -54,6 +55,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 403, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(void)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 
     [Theory]
@@ -82,7 +84,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, expectedStatusCode, expectedType));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -92,5 +94,6 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
     }
 }

--- a/tests/Ardalis.Result.UnitTests/PagedResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/PagedResultConstructor.cs
@@ -151,4 +151,15 @@ public class PagedResultConstructor
         Assert.Equal(ResultStatus.Forbidden, result.Status);
         Assert.Equal(_pagedInfo, result.PagedInfo);
     }
+
+    [Fact]
+    public void InitializesStatusToUnavailableGivenUnavailableFactoryCall()
+    {
+        var result = Result<object>
+            .Unavailable()
+            .ToPagedResult(_pagedInfo);
+
+        Assert.Equal(ResultStatus.Unavailable, result.Status);
+        Assert.Equal(_pagedInfo, result.PagedInfo);
+    }
 }

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -184,6 +184,17 @@ public class ResultConstructor
     }
 
     [Fact]
+    public void InitializesStatusToUnavailableGivenUnavailableFactoryCallWithString()
+    {
+        var errorMessage = "Service Unavailable";
+        var result = Result<object>.Unavailable(errorMessage);
+
+        Assert.Equal(ResultStatus.Unavailable, result.Status);
+        Assert.Equal(errorMessage, result.Errors.First());
+    }
+    
+
+    [Fact]
     public void InitializedIsSuccessTrueForSuccessFactoryCall()
     {
         var result = Result<object>.Success(new object());

--- a/tests/Ardalis.Result.UnitTests/ResultMap.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultMap.cs
@@ -164,6 +164,18 @@ namespace Ardalis.Result.UnitTests
             actual.Errors.Single().Should().Be(expectedMessage);
         }
 
+        [Fact]
+        public void ShouldProduceUnavailableWithError()
+        {
+            string expectedMessage = "Something unavailable";
+            var result = Result<int>.Unavailable(expectedMessage);
+
+            var actual = result.Map(val => val.ToString());
+
+            actual.Status.Should().Be(ResultStatus.Unavailable);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
         private record Foo(string Bar);
 
         private class FooDto

--- a/tests/Ardalis.Result.UnitTests/ResultVoidConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidConstructor.cs
@@ -171,4 +171,16 @@ public class ResultVoidConstructor
         result.Status.Should().Be(ResultStatus.Conflict);
         result.Errors.Single().Should().Be(errorMessage);
     }
+
+    [Fact]
+    public void InitializeUnavailableResultWithFactoryMethodWithErrors()
+    {
+        var errorMessage = "Something unavailable";
+        var result = Result.Unavailable(errorMessage);
+
+        result.Value.Should().BeNull();
+        result.Status.Should().Be(ResultStatus.Unavailable);
+        result.Errors.Single().Should().Be(errorMessage);
+    }
+    
 }

--- a/tests/Ardalis.Result.UnitTests/ResultVoidMap.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidMap.cs
@@ -92,5 +92,16 @@ namespace Ardalis.Result.UnitTests
             actual.Status.Should().Be(ResultStatus.Conflict);
             actual.Value.Should().BeNull();
         }
+
+        [Fact]
+        public void ShouldProduceUnavailable()
+        {
+            var result = Result.Unavailable();
+
+            var actual = result.Map(_ => "This should be ignored");
+
+            actual.Status.Should().Be(ResultStatus.Unavailable);
+            actual.Value.Should().BeNull();
+        }
     }
 }

--- a/tests/Ardalis.Result.UnitTests/ResultVoidToResultOfT.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidToResultOfT.cs
@@ -103,5 +103,14 @@ public class ResultVoidToResultOfT
         result.Value.Should().BeNull();
     }
 
+    [Fact]
+    public void ConvertFromUnavailableResultOfUnit()
+    {
+        var result = DoBusinessOperationExample<object>(Result.Unavailable());
+
+        result.Status.Should().Be(ResultStatus.Unavailable);
+        result.Value.Should().BeNull();
+    }
+
     public Result<T> DoBusinessOperationExample<T>(Result testValue) => testValue;
 }


### PR DESCRIPTION
When making calls to downstream services or databases transient errors could occur that may get resolved if the operation is retried.

This PR adds an Unavailable result status and a mapping to a 503 Service Unavailable http result.

Usage scenarios:
1. A service adds a resiliency layer (using Polly for example) to handle retries.
instead of handling various exception or error types in the shared resiliency layer, the developer can handle these cases closer to where they occur and return Result.Unavailable. the resiliency layer can now be made generic, and error agnostic, and retry based on the result status.

2. while making a call to a downstream service, we get some transient error (database unavailable). the service layer can handle the error and return  Result.Unavailable and the result will be converted to a 503 http response instead of a default 500 or 422.
Callers of our API get a better experience and can add their own resiliency layers if needed.