### PR TITLE
Fix Issue with Serializing Type When Using System.Text.Json

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Runtime" Version="4.3.1" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>

--- a/src/Ardalis.Result/Ardalis.Result.csproj
+++ b/src/Ardalis.Result/Ardalis.Result.csproj
@@ -13,4 +13,7 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
 </Project>

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Ardalis.Result
 {
@@ -10,10 +11,6 @@ namespace Ardalis.Result
         public Result(T value)
         {
             Value = value;
-            if (Value != null)
-            {
-                ValueType = Value.GetType();
-            }
         }
 
         protected internal Result(T value, string successMessage) : this(value)
@@ -40,15 +37,14 @@ namespace Ardalis.Result
 
         public T Value { get; }
 
-        public Type ValueType { get; private set; }
+        [JsonIgnore]
+        public Type ValueType => typeof(T);
         public ResultStatus Status { get; protected set; } = ResultStatus.Ok;
         public bool IsSuccess => Status == ResultStatus.Ok;
         public string SuccessMessage { get; protected set; } = string.Empty;
         public string CorrelationId { get; protected set; } = string.Empty;
         public IEnumerable<string> Errors { get; protected set; } = new List<string>();
         public List<ValidationError> ValidationErrors { get; protected set; } = new List<ValidationError>();
-
-        public void ClearValueType() => ValueType = null;
 
         /// <summary>
         /// Returns the current value.

--- a/tests/Ardalis.Result.UnitTests/SystemTextJsonSerializer.cs
+++ b/tests/Ardalis.Result.UnitTests/SystemTextJsonSerializer.cs
@@ -1,0 +1,57 @@
+﻿using System.Text.Json;
+using Xunit;
+
+namespace Ardalis.Result.UnitTests
+{
+    public class SystemTextJsonSerializer
+    {
+        [Fact]
+        public void ShouldSerializeResultOfValueType()
+        {
+            var result = Result.Success(5);
+            string expected = "{\"Value\":5,\"Status\":0,\"IsSuccess\":true,\"SuccessMessage\":\"\",\"CorrelationId\":\"\",\"Errors\":[],\"ValidationErrors\":[]}";
+
+            var json = JsonSerializer.Serialize(result);
+
+            Assert.Equal(expected, json);
+        }
+
+        [Fact]
+        public void ShouldSerializeResultOfReferenceType()
+        {
+            var result = Result.Success(new Foo { Bar = "Result!" });
+            string expected = "{\"Value\":{\"Bar\":\"Result!\"},\"Status\":0,\"IsSuccess\":true,\"SuccessMessage\":\"\",\"CorrelationId\":\"\",\"Errors\":[],\"ValidationErrors\":[]}";
+
+            var json = JsonSerializer.Serialize(result);
+
+            Assert.Equal(expected, json);
+        }
+
+        [Fact]
+        public void ShouldDeserializeResultOfValueType()
+        {
+            var expected = Result.Success(10);
+            string json = "{\"Value\":10,\"Status\":0,\"IsSuccess\":true,\"SuccessMessage\":\"\",\"CorrelationId\":\"\",\"Errors\":[],\"ValidationErrors\":[]}";
+
+            var result = JsonSerializer.Deserialize<Result<int>>(json);
+
+            Assert.Equivalent(expected, result);
+        }
+
+        [Fact]
+        public void ShouldDeserializeResultOfReferenceType()
+        {
+            var expected = Result.Success(new Foo { Bar = "Result!" });
+            string json = "{\"Value\":{\"Bar\":\"Result!\"},\"Status\":0,\"IsSuccess\":true,\"SuccessMessage\":\"\",\"CorrelationId\":\"\",\"Errors\":[],\"ValidationErrors\":[]}";
+
+            var result = JsonSerializer.Deserialize<Result<Foo>>(json);
+
+            Assert.Equivalent(expected, result);
+        }
+
+        private class Foo
+        {
+            public string Bar { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Description of Changes: 

Fixes #91 
Fixes issue with lack of support for serialization of `Type` when using `System.Text.Json`'s serializer by removing the property from the exported json altogether. Unit tests show output of serialization for reference.


Pros:

- Fixes issue
- Makes Type an expression which simplifies Result's available API and reduces code (which appeared to be unused based on Samples, Docs, and Tests).

Cons:

- Adds additional but compatible dependency on `System.Text.Json` to core `Ardalis.Result` for .NET Standard users. This is already a "baked in" dependency in .NET 7 version.

https://www.nuget.org/packages/System.Text.Json/7.0.3#supportedframeworks-body-tab


Did you add tests? 
- [x] - Yes
- [ ] - No

If no, why not? 

N/A