### PR TITLE
Add params overload for Invalid factory method

### DIFF
--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -92,6 +92,16 @@ namespace Ardalis.Result
         /// </summary>
         /// <param name="validationErrors">A list of validation errors encountered</param>
         /// <returns>A Result</returns>
+        public new static Result Invalid(params ValidationError[] validationErrors)
+        {
+            return new Result(ResultStatus.Invalid) { ValidationErrors = new List<ValidationError>(validationErrors) };
+        }
+
+        /// <summary>
+        /// Represents validation errors that prevent the underlying service from completing.
+        /// </summary>
+        /// <param name="validationErrors">A list of validation errors encountered</param>
+        /// <returns>A Result</returns>
         public new static Result Invalid(List<ValidationError> validationErrors)
         {
             return new Result(ResultStatus.Invalid) { ValidationErrors = validationErrors };

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -122,6 +122,16 @@ namespace Ardalis.Result
         /// </summary>
         /// <param name="validationErrors">A list of validation errors encountered</param>
         /// <returns>A Result<typeparamref name="T"/></returns>
+        public static Result<T> Invalid(params ValidationError[] validationErrors)
+        {
+            return new Result<T>(ResultStatus.Invalid) { ValidationErrors = new List<ValidationError>(validationErrors) };
+        }
+
+        /// <summary>
+        /// Represents validation errors that prevent the underlying service from completing.
+        /// </summary>
+        /// <param name="validationErrors">A list of validation errors encountered</param>
+        /// <returns>A Result<typeparamref name="T"/></returns>
         public static Result<T> Invalid(List<ValidationError> validationErrors)
         {
             return new Result<T>(ResultStatus.Invalid) { ValidationErrors = validationErrors };

--- a/src/Ardalis.Result/ValidationError.cs
+++ b/src/Ardalis.Result/ValidationError.cs
@@ -2,6 +2,23 @@
 {
     public class ValidationError
     {
+        public ValidationError()
+        {
+        }
+
+        public ValidationError(string errorMessage)
+        {
+            ErrorMessage = errorMessage;
+        }
+
+        public ValidationError(string identifier, string errorMessage, string errorCode, ValidationSeverity severity)
+        {
+            Identifier = identifier;
+            ErrorMessage = errorMessage;
+            ErrorCode = errorCode;
+            Severity = severity;
+        }
+
         public string Identifier { get; set; }
         public string ErrorMessage { get; set; }
         public string ErrorCode { get; set; }


### PR DESCRIPTION
Added an overload for the Invalid factory method of `Result` and `Result<T>` that accepts `params ValidationError[]`
Also adds 2 QOL constructors to the ValidationError class.

Closes #149