### PR TITLE
closes #161 Auto-Evaluation of the Status property when Errors ou ValidationErrors are added to the result.

### DIFF
--- a/src/Ardalis.Result/IResult.cs
+++ b/src/Ardalis.Result/IResult.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Ardalis.Result
 {
     public interface IResult
     {
         ResultStatus Status { get; }
-        IEnumerable<string> Errors { get; }
-        List<ValidationError> ValidationErrors { get; }
+        ObservableCollection<string> Errors { get; }
+        ObservableCollection<ValidationError> ValidationErrors { get; }
         Type ValueType { get; }
         Object GetValue();
     }

--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Ardalis.Result
 {
@@ -57,7 +59,14 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result Error(params string[] errorMessages)
         {
-            return new Result(ResultStatus.Error) { Errors = errorMessages };
+            Result result = new Result(ResultStatus.Error);
+
+            if (errorMessages != null && errorMessages.Length > 0)
+                result.Errors = new ObservableCollection<string>(errorMessages);
+
+            result.Initialize();
+
+            return result;
         }
 
         /// <summary>
@@ -70,11 +79,15 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public static Result ErrorWithCorrelationId(string correlationId, params string[] errorMessages)
         {
-            return new Result(ResultStatus.Error)
-            {
-                CorrelationId = correlationId,
-                Errors = errorMessages
-            };
+            Result result = new Result(ResultStatus.Error);
+            result.CorrelationId = correlationId;
+
+            if (errorMessages != null && errorMessages.Length > 0)
+                result.Errors = new ObservableCollection<string>(errorMessages);
+
+            result.Initialize();
+
+            return result;
         }
 
         /// <summary>
@@ -84,7 +97,7 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result Invalid(ValidationError validationError)
         {
-            return new Result(ResultStatus.Invalid) { ValidationErrors = { validationError } };
+            return Invalid(new List<ValidationError> { validationError });
         }
 
         /// <summary>
@@ -94,7 +107,14 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result Invalid(params ValidationError[] validationErrors)
         {
-            return new Result(ResultStatus.Invalid) { ValidationErrors = new List<ValidationError>(validationErrors) };
+            Result result = new Result(ResultStatus.Invalid);
+
+            if (validationErrors != null && validationErrors.Length > 0)
+                result.ValidationErrors = new ObservableCollection<ValidationError>(validationErrors);
+
+            result.Initialize();
+
+            return result;
         }
 
         /// <summary>
@@ -104,7 +124,7 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result Invalid(List<ValidationError> validationErrors)
         {
-            return new Result(ResultStatus.Invalid) { ValidationErrors = validationErrors };
+            return Invalid(validationErrors.ToArray());
         }
 
         /// <summary>
@@ -113,7 +133,7 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result NotFound()
         {
-            return new Result(ResultStatus.NotFound);
+            return NotFound(null);
         }
 
         /// <summary>
@@ -124,7 +144,14 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result NotFound(params string[] errorMessages)
         {
-            return new Result(ResultStatus.NotFound) { Errors = errorMessages };
+            Result result = new Result(ResultStatus.NotFound);
+
+            if (errorMessages != null && errorMessages.Length > 0)
+                result.Errors = new ObservableCollection<string>(errorMessages);
+
+            result.Initialize();
+
+            return result;
         }
 
         /// <summary>
@@ -134,7 +161,9 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result Forbidden()
         {
-            return new Result(ResultStatus.Forbidden);
+            Result result = new Result(ResultStatus.Forbidden);
+            result.Initialize();
+            return result;
         }
 
         /// <summary>
@@ -144,9 +173,11 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public new static Result Unauthorized()
         {
-            return new Result(ResultStatus.Unauthorized);
+            Result result = new Result(ResultStatus.Unauthorized);
+            result.Initialize();
+            return result;
         }
-        
+
         /// <summary>
         /// Represents a situation where a service is in conflict due to the current state of a resource,
         /// such as an edit conflict between multiple concurrent updates.
@@ -155,7 +186,7 @@ namespace Ardalis.Result
         /// <returns>A Result<typeparamref name="T"/></returns>
         public new static Result Conflict()
         {
-            return new Result(ResultStatus.Conflict);
+            return Conflict(null);
         }
 
         /// <summary>
@@ -168,7 +199,14 @@ namespace Ardalis.Result
         /// <returns>A Result<typeparamref name="T"/></returns>
         public new static Result Conflict(params string[] errorMessages)
         {
-            return new Result(ResultStatus.Conflict) { Errors = errorMessages };
+            Result result = new Result(ResultStatus.Conflict);
+
+            if (errorMessages != null && errorMessages.Length > 0)
+                result.Errors = new ObservableCollection<string>(errorMessages);
+
+            result.Initialize();
+
+            return result;
         }
 
         /// <summary>
@@ -180,9 +218,16 @@ namespace Ardalis.Result
         /// <returns></returns>
         public new static Result Unavailable(params string[] errorMessages)
         {
-            return new Result(ResultStatus.Unavailable) { Errors = errorMessages };
+            Result result = new Result(ResultStatus.Unavailable);
+
+            if (errorMessages != null && errorMessages.Length > 0)
+                result.Errors = new ObservableCollection<string>(errorMessages);
+
+            result.Initialize();
+
+            return result;
         }
-        
+
         /// Represents a critical error that occurred during the execution of the service.
         /// Everything provided by the user was valid, but the service was unable to complete due to an exception.
         /// See also HTTP 500 Internal Server Error: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
@@ -191,7 +236,14 @@ namespace Ardalis.Result
         /// <returns>A Result</returns>
         public static Result CriticalError(params string[] errorMessages)
         {
-            return new Result(ResultStatus.CriticalError) { Errors = errorMessages };
+            Result result = new Result(ResultStatus.CriticalError);
+
+            if (errorMessages != null && errorMessages.Length > 0)
+                result.Errors = new ObservableCollection<string>(errorMessages);
+
+            result.Initialize();
+
+            return result;
         }
     }
 }

--- a/src/Ardalis.Result/ResultExtensions.cs
+++ b/src/Ardalis.Result/ResultExtensions.cs
@@ -24,7 +24,7 @@ namespace Ardalis.Result
                         : Result<TDestination>.NotFound();
                 case ResultStatus.Unauthorized: return Result<TDestination>.Unauthorized();
                 case ResultStatus.Forbidden: return Result<TDestination>.Forbidden();
-                case ResultStatus.Invalid: return Result<TDestination>.Invalid(result.ValidationErrors);
+                case ResultStatus.Invalid: return Result<TDestination>.Invalid(result.ValidationErrors.ToArray());
                 case ResultStatus.Error: return Result<TDestination>.Error(result.Errors.ToArray());
                 case ResultStatus.Conflict: return result.Errors.Any()
                                         ? Result<TDestination>.Conflict(result.Errors.ToArray())

--- a/tests/Ardalis.Result.UnitTests/ErrorsAndValidationErrorsChanged.cs
+++ b/tests/Ardalis.Result.UnitTests/ErrorsAndValidationErrorsChanged.cs
@@ -1,0 +1,383 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ardalis.Result.UnitTests
+{
+    public class ErrorsAndValidationErrorsChanged
+    {
+        [Fact]
+        public void ValidationErrorsChanged()
+        {
+            Result result = Result.Success();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+
+            // Adding a validation error
+            result.ValidationErrors.Add(new ValidationError("Error 1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            // clearing the validation errors
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public void ErrorsChanged()
+        {
+            Result result = Result.Success();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+
+            // Adding a validation error
+            result.Errors.Add("Error 1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            // clearing the validation errors
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public void ErrorAndValidationErrorChanged()
+        {
+            Result result = Result.Success();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+
+            // Adding a validation error
+            result.ValidationErrors.Add(new ValidationError("Error 1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            // Adding an error
+            result.Errors.Add("Error 1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            // clearing the errors (still remain one Validation Error, so it's Invalid)
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public void SettingTheValidationErrorsProperty()
+        {
+            Result result = Result.Success();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+
+            List<ValidationError> validationErrors = new List<ValidationError>();
+            validationErrors.Add(new ValidationError("Error 1"));
+            validationErrors.Add(new ValidationError("Error 2"));
+
+            result.ValidationErrors = new ObservableCollection<ValidationError>(validationErrors);
+
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+        }
+
+        [Fact]
+        public void SettingTheErrorsProperty()
+        {
+            Result result = Result.Success();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+
+            List<string> errors = new List<string>();
+            errors.Add("Error 1");
+            errors.Add("Error 2");
+
+            result.Errors = new ObservableCollection<string>(errors);
+
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckOkInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Success(); // Initial state
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(true);
+            result.Status.Should().Be(ResultStatus.Ok); // Initial state
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckErrorInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Error(); // Initial state
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error); // Initial state
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckInvalidInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Invalid(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid);
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckConflictInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Conflict(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Conflict);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Conflict); // Should not be changed?
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Conflict); // Should not be changed?
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Conflict); // Should not be changed?
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Conflict); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckUnavailableInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Unavailable(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unavailable);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unavailable); // Should not be changed?
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unavailable); // Should not be changed?
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unavailable); // Should not be changed?
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unavailable); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckCriticalErrorInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.CriticalError(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.CriticalError);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.CriticalError); // Should not be changed?
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.CriticalError); // Should not be changed?
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.CriticalError); // Should not be changed?
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.CriticalError); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckErrorWithCorrelationIdInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.ErrorWithCorrelationId("correlationId"); // Initial State
+
+            Result result2 = Result.ErrorWithCorrelationId("correlationId", null); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid); // Should change to Invalid
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error);// Should change to Error
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Invalid); // Should change to Invalid
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Error); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckForbidedenInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Forbidden(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Forbidden);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Forbidden); // Should not be changed?
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Forbidden); // Should not be changed?
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Forbidden); // Should not be changed?
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Forbidden); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckNotFoundInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.NotFound(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.NotFound);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.NotFound); // Should not be changed?
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.NotFound); // Should not be changed?
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.NotFound); // Should not be changed?
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.NotFound); // Initial state 
+        }
+
+        /// <summary>
+        /// Checks if the initial state is correct after addind and removing Errors and ValidationErros from the result
+        /// </summary>
+        [Fact]
+        public void CheckUnauthorizedInitialStateAfterChangeErrorsAndValidationErrors()
+        {
+            Result result = Result.Unauthorized(); // Initial State
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unauthorized);
+
+            result.ValidationErrors.Add(new ValidationError("Validation Error1"));
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unauthorized); // Should not be changed?
+
+            result.Errors.Add("Error1");
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unauthorized); // Should not be changed?
+
+            result.Errors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unauthorized); // Should not be changed?
+
+            result.ValidationErrors.Clear();
+            result.IsSuccess.Should().Be(false);
+            result.Status.Should().Be(ResultStatus.Unauthorized); // Initial state 
+        }
+    }
+}

--- a/tests/Ardalis.Result.UnitTests/PagedResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/PagedResultConstructor.cs
@@ -91,6 +91,17 @@ public class PagedResultConstructor
     }
 
     [Fact]
+    public void InitializesStatusToInvalidGivenInvalidFactoryCall()
+    {
+        var result = Result<object>
+            .Invalid()
+            .ToPagedResult(_pagedInfo);
+
+        Assert.Equal(ResultStatus.Invalid, result.Status);
+        Assert.Equal(_pagedInfo, result.PagedInfo);
+    }
+
+    [Fact]
     public void InitializesStatusToErrorAndSetsErrorMessageGivenErrorFactoryCall()
     {
         string errorMessage = "Something bad happened.";


### PR DESCRIPTION
Auto-evaluate the Status property when Errors ou ValidationErrors are added to the result. 
**It only works when the result is created as Ok(), Error() ou Invalid()**.

The following unit test describes the functioning of this PR
```
 [Fact]
 public void ErrorAndValidationErrorChanged()
 {
     Result result = Result.Success(); // Created as Ok
     result.IsSuccess.Should().Be(true);
     result.Status.Should().Be(ResultStatus.Ok);

     // Adding a validation error
     result.ValidationErrors.Add(new ValidationError("Validation Error 1"));
     result.IsSuccess.Should().Be(false);
     result.Status.Should().Be(ResultStatus.Invalid); // <- Status changed to Invalid

     // Adding an Error
     result.Errors.Add("Error 1");
     result.IsSuccess.Should().Be(false);
     result.Status.Should().Be(ResultStatus.Error); // <- Status changed to Error

     // clearing the errors (still remain one Validation Error, so it's Invalid)
     result.Errors.Clear();
     result.IsSuccess.Should().Be(false);
     result.Status.Should().Be(ResultStatus.Invalid); // <- Status changed to Invalid

     // clearing the validation errors. It should revert back to the initial status
     result.ValidationErrors.Clear();
     result.IsSuccess.Should().Be(true);
     result.Status.Should().Be(ResultStatus.Ok); // <- reverted back to its initial state
 }
```

