### PR TITLE
Fix 181

### DIFF
--- a/src/Ardalis.Result/ErrorList.cs
+++ b/src/Ardalis.Result/ErrorList.cs
@@ -7,4 +7,4 @@ namespace Ardalis.Result;
 /// </summary>
 /// <param name="ErrorMessages"></param>
 /// <param name="CorrelationId"></param>
-public record ErrorList(IEnumerable<string> ErrorMessages, string? CorrelationId);
+public record ErrorList(IEnumerable<string> ErrorMessages, string? CorrelationId = null);

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -132,6 +132,17 @@ namespace Ardalis.Result
 
         /// <summary>
         /// Represents an error that occurred during the execution of the service.
+        /// A single error message may be provided and will be exposed via the Errors property.
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        /// <returns></returns>
+        public static Result<T> Error(string errorMessage)
+        {
+            return new Result<T>(ResultStatus.Error) { Errors = new[] { errorMessage } };
+        }
+
+        /// <summary>
+        /// Represents an error that occurred during the execution of the service.
         /// Error messages may be provided and will be exposed via the Errors property.
         /// </summary>
         /// <param name="error">An optional instance of ErrorList with list of string error messages and CorrelationId.</param>

--- a/tests/Ardalis.Result.UnitTests/PagedResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/PagedResultConstructor.cs
@@ -96,8 +96,10 @@ public class PagedResultConstructor
     {
         string errorMessage = "Something bad happened.";
         string correlationId = Guid.NewGuid().ToString();
+        ErrorList errors = new(new[] { errorMessage }, correlationId);
+
         var result = Result<object>
-            .Error(new([errorMessage], correlationId))
+            .Error(errors)
             .ToPagedResult(_pagedInfo);
 
         Assert.Equal(ResultStatus.Error, result.Status);

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -95,7 +95,7 @@ public class ResultConstructor
         Assert.Equal(value, result.Value);
         Assert.Equal(message, result.SuccessMessage);
     }
-    
+
     [Theory]
     [InlineData(null)]
     [InlineData(123)]
@@ -104,12 +104,12 @@ public class ResultConstructor
     {
         string location = "https://github.com/ardalis/Result";
         var result = Result<object>.Created(value, location);
-        
+
         Assert.Equal(ResultStatus.Created, result.Status);
         Assert.Equal(location, result.Location);
         Assert.True(result.IsSuccess);
     }
-    
+
     [Theory]
     [InlineData(null)]
     [InlineData(123)]
@@ -117,12 +117,12 @@ public class ResultConstructor
     public void InitializesStatusToCreatedGivenCreatedFactoryCall(object value)
     {
         var result = Result<object>.Created(value);
-        
+
         Assert.Equal(ResultStatus.Created, result.Status);
         Assert.Equal(result.Location, string.Empty);
         Assert.True(result.IsSuccess);
     }
-    
+
     [Fact]
     public void InitializesStatusToErrorGivenErrorFactoryCall()
     {
@@ -132,15 +132,37 @@ public class ResultConstructor
     }
 
     [Fact]
+    public void InitializesStatusToErrorGivenErrorFactoryCallWithSimpleMessage()
+    {
+        string errorMessage = Guid.NewGuid().ToString();
+        var result = Result<object>.Error(errorMessage);
+
+        Assert.Equal(ResultStatus.Error, result.Status);
+        Assert.Equal(errorMessage, result.Errors.Single());
+    }
+
+    [Fact]
     public void InitializesStatusToErrorAndSetsErrorMessageGivenErrorFactoryCall()
     {
         string errorMessage = "Something bad happened.";
         string correlationId = Guid.NewGuid().ToString();
-        var result = Result<object>.Error(new([errorMessage], correlationId));
+        ErrorList errors = new(new[] { errorMessage }, correlationId);
+        var result = Result<object>.Error(errors);
 
         Assert.Equal(ResultStatus.Error, result.Status);
         Assert.Equal(errorMessage, result.Errors.Single());
-      Assert.Equal(correlationId, result.CorrelationId);
+        Assert.Equal(correlationId, result.CorrelationId);
+    }
+
+    [Fact]
+    public void InitializesStatusToErrorAndSetsErrorMessageGivenErrorFactoryCallWithoutCorrelationId()
+    {
+        string errorMessage = "Something bad happened.";
+        ErrorList errors = new(new[] { errorMessage });
+        var result = Result<object>.Error(errors);
+
+        Assert.Equal(ResultStatus.Error, result.Status);
+        Assert.Equal(errorMessage, result.Errors.Single());
     }
 
     [Fact]
@@ -185,7 +207,7 @@ public class ResultConstructor
         Assert.Equal(ResultStatus.NotFound, result.Status);
         Assert.Equal(errorMessage, result.Errors.First());
     }
-    
+
     [Fact]
     public void InitializesStatusToConflictGivenConflictFactoryCall()
     {
@@ -222,7 +244,7 @@ public class ResultConstructor
         Assert.Equal(ResultStatus.Unavailable, result.Status);
         Assert.Equal(errorMessage, result.Errors.First());
     }
-    
+
 
     [Fact]
     public void InitializedIsSuccessTrueForSuccessFactoryCall()
@@ -271,7 +293,7 @@ public class ResultConstructor
 
         Assert.False(result.IsSuccess);
     }
-    
+
     [Fact]
     public void InitializedIsSuccessFalseForConflictFactoryCall()
     {
@@ -292,7 +314,7 @@ public class ResultConstructor
     public void InitializesStatusToNoContentForNoContentFactoryCall()
     {
         var result = Result<object>.NoContent();
-        
+
         Assert.True(result.IsSuccess);
     }
 }


### PR DESCRIPTION
Fixes #181
Make ErrorList correlationId optional
Allow Result.Error to take a single error message string