### PR TITLE
Fix unhandled ResultStatus.NoContent in MinimalApiResultExtensions.ToMinimalApiResult

### DIFF
--- a/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Text;
 
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -37,6 +36,7 @@ public static partial class ResultExtensions
         {
             ResultStatus.Ok => result is Result ? Results.Ok() : Results.Ok(result.GetValue()),
             ResultStatus.Created => Results.Created("", result.GetValue()),
+            ResultStatus.NoContent => Results.NoContent(),
             ResultStatus.NotFound => NotFoundEntity(result),
             ResultStatus.Unauthorized => UnAuthorized(result),
             ResultStatus.Forbidden => Forbidden(result),

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
@@ -1,0 +1,38 @@
+#if NET7_0_OR_GREATER
+
+using Ardalis.Result.AspNetCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ardalis.Result.AspNetCore.UnitTests;
+
+public class MinimalApiResultExtensionsCoverage : BaseResultConventionTest
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public MinimalApiResultExtensionsCoverage(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    private class TestResult(ResultStatus status) : Result(status);
+    
+    [Fact]
+    public void ToMinimalApiResultHandlesAllResultStatusValues()
+    {
+        foreach (ResultStatus resultStatus in Enum.GetValues(typeof(ResultStatus)))
+        {
+            Result result = new TestResult(resultStatus);
+            try
+            {
+                Microsoft.AspNetCore.Http.IResult minimalApiResult = result.ToMinimalApiResult();
+            }
+            catch (NotSupportedException e)
+            {
+                Assert.Fail(
+                    $"Unhandled ResultStatus {resultStatus} in MinimalApiResultExtensions.ToMinimalApiResult: {e}");
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Added an xUnit test to avoid future unhandled ResultStatus values
Fixes #191