### PR TITLE
Add support for HttpStatusCode: Created to the ResultStatus mapping

### DIFF
--- a/sample/Ardalis.Result.Sample.Core/Services/WeatherService.cs
+++ b/sample/Ardalis.Result.Sample.Core/Services/WeatherService.cs
@@ -56,6 +56,19 @@ namespace Ardalis.Result.Sample.Core.Services
                         ErrorMessage = "PostalCode is required" }
                     });
             }
+            
+            // Test value to return Created result with a location
+            if (model.PostalCode == "12345")
+            {
+                return Result<IEnumerable<WeatherForecast>>.Created(
+                    Enumerable.Range(1, 1).Select(index =>
+                        new WeatherForecast
+                        {
+                            Date = DateTime.Now,
+                            TemperatureC = 0,
+                            Summary = Summaries[0]
+                        }), "weatherforecast/12345");
+            }
 
             // test value
             if (model.PostalCode == "55555")

--- a/src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs
@@ -74,6 +74,17 @@ namespace Ardalis.Result.AspNetCore
                     return typeof(Result).IsInstanceOfType(result)
                         ? (ActionResult)controller.StatusCode(statusCode)
                         : controller.StatusCode(statusCode, result.GetValue());
+                case ResultStatus.Created:
+                    if(string.IsNullOrEmpty(result.Location))
+                        return controller.Created((string?)null, result.GetValue());
+                    
+                    var httpRequest = controller.HttpContext.Request;
+                    var locationUri = new UriBuilder(httpRequest.Scheme, 
+                        httpRequest.Host.Host, 
+                        httpRequest.Host.Port ?? -1,
+                        result.Location).Uri.AbsoluteUri;
+
+                    return controller.Created(locationUri, result.GetValue());
                 default:
                     return resultStatusOptions.ResponseType == null
                         ? (ActionResult)controller.StatusCode(statusCode)

--- a/src/Ardalis.Result.AspNetCore/ResultConvention.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultConvention.cs
@@ -81,7 +81,8 @@ namespace Ardalis.Result.AspNetCore
 
                 var resultStatuses = attr?.ResultStatuses ?? _map.Keys;
 
-                foreach (var status in resultStatuses.Where(s => s != ResultStatus.Ok))
+                foreach (var status in resultStatuses.Where(s => 
+                             s is not (ResultStatus.Ok or ResultStatus.Created)))
                 {
                     var info = _map[status];
                     AddProducesResponseTypeAttribute(action.Filters, (int)info.GetStatusCode(method), info.ResponseType);

--- a/src/Ardalis.Result.AspNetCore/ResultStatusMap.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultStatusMap.cs
@@ -26,6 +26,7 @@ namespace Ardalis.Result.AspNetCore
         public ResultStatusMap AddDefaultMap()
         {
             return For(ResultStatus.Ok, HttpStatusCode.OK)
+                .For(ResultStatus.Created, HttpStatusCode.Created)
                 .For(ResultStatus.Error, (HttpStatusCode)422, resultStatusOptions => resultStatusOptions
                     .With(UnprocessableEntity))
                 .For(ResultStatus.Forbidden, HttpStatusCode.Forbidden)

--- a/src/Ardalis.Result/IResult.cs
+++ b/src/Ardalis.Result/IResult.cs
@@ -10,5 +10,6 @@ namespace Ardalis.Result
         IEnumerable<ValidationError> ValidationErrors { get; }
         Type ValueType { get; }
         object GetValue();
+        string Location { get; }
     }
 }

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -345,4 +345,20 @@ public class ResultConstructor
 
         Assert.True(result.IsSuccess);
     }
+    
+    [Fact]
+    public void InitializedIsSuccessTrueForCreatedFactoryCall()
+    {
+        var result = Result<object>.Created(new object());
+        
+        Assert.True(result.IsSuccess);
+    }
+    
+    [Fact]
+    public void InitializedIsSuccessTrueForCreatedWithLocationFactoryCall()
+    {
+        var result = Result<object>.Created(new object(), "sample/endpoint");
+        
+        Assert.True(result.IsSuccess);
+    }
 }


### PR DESCRIPTION
Fixes #196

An assumption I made for setting the location header is that we could allow users to only define a relative location by deriving the base URL from the controller that is calling .ToActionResult on the Created result.

Is this OK or do you think we ought to allow them to specify the entire URL, or both?

Sorry If I've overlooked anything on this, it is my ~~first~~ second PR.

Old PR: #197 