### PR TITLE
Add Result.Created void methods so that return Result type is implicitly handled.

### DIFF
--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -49,6 +49,30 @@ namespace Ardalis.Result
             return new Result<T>(value, successMessage);
         }
 
+		/// <summary>
+		/// Represents a successful operation that resulted in the creation of a new resource.
+		/// Accepts a value as the result of the operation.
+		/// </summary>		
+		/// <param name="value">Sets the Value property</param>
+		/// <returns>A Result<typeparamref name="T"/></returns>
+		public static Result<T> Created<T>(T value)
+		{
+			return Result<T>.Created(value);
+		}
+
+		/// <summary>
+		/// Represents a successful operation that resulted in the creation of a new resource.
+		/// Accepts a value as the result of the operation.
+		/// Accepts a location for the new resource.
+		/// </summary>		
+		/// <param name="value">Sets the Value property</param>
+		/// <param name="location">The location of the newly created resource</param>
+		/// <returns>A Result<typeparamref name="T"/></returns>
+		public static Result<T> Created<T>(T value, string location)
+		{
+			return Result<T>.Created(value, location);
+		}
+
         /// <summary>
         /// Represents an error that occurred during the execution of the service.
         /// Error messages may be provided and will be exposed via the Errors property.

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -114,7 +114,7 @@ namespace Ardalis.Result
         /// <returns>A Result<typeparamref name="T"/> with status Created.</returns>
         public static Result<T> Created(T value)
         {
-            return new Result<T>(ResultStatus.Created) { Value = value };
+            return new Result<T>(value) { Status = ResultStatus.Created };
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Ardalis.Result
         /// <returns>A Result<typeparamref name="T"/> with status Created.</returns>
         public static Result<T> Created(T value, string location)
         {
-            return new Result<T>(ResultStatus.Created) { Value = value, Location = location };
+            return new Result<T>(value) { Status = ResultStatus.Created, Location = location };
         }
 
         /// <summary>

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -114,7 +114,7 @@ namespace Ardalis.Result
         /// <returns>A Result<typeparamref name="T"/> with status Created.</returns>
         public static Result<T> Created(T value)
         {
-            return new Result<T>(value) { Status = ResultStatus.Created };
+            return new Result<T>(ResultStatus.Created) { Value = value };
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Ardalis.Result
         /// <returns>A Result<typeparamref name="T"/> with status Created.</returns>
         public static Result<T> Created(T value, string location)
         {
-            return new Result<T>(value) { Status = ResultStatus.Created, Location = location };
+            return new Result<T>(ResultStatus.Created) { Value = value, Location = location };
         }
 
         /// <summary>


### PR DESCRIPTION
Added Result.Created methods to Result.Void static methods so that returned Result type is implicitly handled.

This allows for `return Result.Created(value);` and `return Result.Created(value, location);` to work effortlessly and as expected the same way that `Result.Success(value);` currently works.