### PR TITLE
Add Bind in addition to Map to support Railway Oriented Programming

### DIFF
--- a/src/Ardalis.Result/ResultExtensions.cs
+++ b/src/Ardalis.Result/ResultExtensions.cs
@@ -156,8 +156,8 @@ namespace Ardalis.Result
             var result = await resultTask;
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus<TSource, TDestination>(result),
             };
         }
@@ -169,8 +169,8 @@ namespace Ardalis.Result
             var result = await resultTask;
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus(result),
             };
         }
@@ -181,8 +181,8 @@ namespace Ardalis.Result
         {
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus(result),
             };
         }
@@ -193,8 +193,8 @@ namespace Ardalis.Result
         {
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus(result),
             };
         }
@@ -206,8 +206,8 @@ namespace Ardalis.Result
             var result = await resultTask;
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus<TDestination>(result),
             };
         }
@@ -218,8 +218,8 @@ namespace Ardalis.Result
         {
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus<TSource, TDestination>(result),
             };
         }
@@ -230,8 +230,8 @@ namespace Ardalis.Result
         {
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result.Value),
-                ResultStatus.Created => await bindFunc(result.Value),
+                ResultStatus.Ok => await bindFunc(result.Value).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result.Value).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus(result),
             };
         }
@@ -241,8 +241,8 @@ namespace Ardalis.Result
             var result = await resultTask;
             return result.Status switch
             {
-                ResultStatus.Ok => await bindFunc(result),
-                ResultStatus.Created => await bindFunc(result),
+                ResultStatus.Ok => await bindFunc(result).ConfigureAwait(false),
+                ResultStatus.Created => await bindFunc(result).ConfigureAwait(false),
                 _ => HandleNonSuccessStatus(result),
             };
         }

--- a/src/Ardalis.Result/ResultExtensions.cs
+++ b/src/Ardalis.Result/ResultExtensions.cs
@@ -1,47 +1,338 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Ardalis.Result
 {
     public static class ResultExtensions
     {
         /// <summary>
-        /// Transforms a Result's type from a source type to a destination type. If the Result is successful, the func parameter is invoked on the Result's source value to map it to a destination type.
+        /// Transforms a Result's type from a source type to a destination type.
+        /// If the Result is successful, the func parameter is invoked on the Result's source value to map it to a destination type.
         /// </summary>
-        /// <typeparam name="TSource"></typeparam>
-        /// <typeparam name="TDestination"></typeparam>
-        /// <param name="result"></param>
-        /// <param name="func"></param>
-        /// <returns></returns>
-        /// <exception cref="NotSupportedException"></exception> 
+        /// <typeparam name="TSource">The type of the value contained in the source Result.</typeparam>
+        /// <typeparam name="TDestination">The type of the value to be returned in the destination Result.</typeparam>
+        /// <param name="result">The source Result to transform.</param>
+        /// <param name="func">A function to transform the source value to the destination type.</param>
+        /// <returns>A Result containing the transformed value or the appropriate error status.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the Result status is not supported.</exception>
         public static Result<TDestination> Map<TSource, TDestination>(this Result<TSource> result, Func<TSource, TDestination> func)
         {
-            switch (result.Status)
+            return result.Status switch
             {
-                case ResultStatus.Ok: return func(result);
-                case ResultStatus.Created: return string.IsNullOrEmpty(result.Location)
-                        ? Result<TDestination>.Created(func(result.Value))
-                        : Result<TDestination>.Created(func(result.Value), result.Location);
-                case ResultStatus.NotFound: return result.Errors.Any()
-                        ? Result<TDestination>.NotFound(result.Errors.ToArray())
-                        : Result<TDestination>.NotFound();
-                case ResultStatus.Unauthorized: return result.Errors.Any()
-                                        ? Result<TDestination>.Unauthorized(result.Errors.ToArray())
-                                        : Result<TDestination>.Unauthorized();
-                case ResultStatus.Forbidden: return result.Errors.Any()
-                                        ? Result<TDestination>.Forbidden(result.Errors.ToArray())
-                                        : Result<TDestination>.Forbidden();
-                case ResultStatus.Invalid: return Result<TDestination>.Invalid(result.ValidationErrors);
-                case ResultStatus.Error: return Result<TDestination>.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId));
-                case ResultStatus.Conflict: return result.Errors.Any()
-                                        ? Result<TDestination>.Conflict(result.Errors.ToArray())
-                                        : Result<TDestination>.Conflict();
-                case ResultStatus.CriticalError: return Result<TDestination>.CriticalError(result.Errors.ToArray());
-                case ResultStatus.Unavailable: return Result<TDestination>.Unavailable(result.Errors.ToArray());
-                case ResultStatus.NoContent: return Result<TDestination>.NoContent();
-                default:
-                    throw new NotSupportedException($"Result {result.Status} conversion is not supported.");
-            }
+                ResultStatus.Ok => (Result<TDestination>)func(result),
+                ResultStatus.Created => string.IsNullOrEmpty(result.Location)
+                                        ? Result<TDestination>.Created(func(result.Value))
+                                        : Result<TDestination>.Created(func(result.Value), result.Location),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+        public static Result<TDestination> Map<TDestination>(this Result result, Func<TDestination> func)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => Result<TDestination>.Success(func()),
+                ResultStatus.Created => string.IsNullOrEmpty(result.Location)
+                    ? Result<TDestination>.Created(func())
+                    : Result<TDestination>.Created(func(), result.Location),
+                _ => HandleNonSuccessStatus<TDestination>(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(
+            this Result<TSource> result,
+            Func<TSource, Task<TDestination>> func)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => Result<TDestination>.Success(await func(result.Value)),
+                ResultStatus.Created => string.IsNullOrEmpty(result.Location)
+                    ? Result<TDestination>.Created(await func(result.Value))
+                    : Result<TDestination>.Created(await func(result.Value), result.Location),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+      
+        public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(
+            this Task<Result<TSource>> resultTask,
+            Func<TSource, Task<TDestination>> func)
+        {
+            var result = await resultTask;
+            return result.Status switch
+            {
+                ResultStatus.Ok => Result<TDestination>.Success(await func(result.Value)),
+                ResultStatus.Created => string.IsNullOrEmpty(result.Location)
+                    ? Result<TDestination>.Created(await func(result.Value))
+                    : Result<TDestination>.Created(await func(result.Value), result.Location),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> MapAsync<TDestination>(
+            this Result result,
+            Func<Task<TDestination>> func)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => Result<TDestination>.Success(await func()),
+                ResultStatus.Created => string.IsNullOrEmpty(result.Location)
+                    ? Result<TDestination>.Created(await func())
+                    : Result<TDestination>.Created(await func(), result.Location),
+                _ => HandleNonSuccessStatus<TDestination>(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> MapAsync<TDestination>(
+            this Task<Result> resultTask,
+            Func<Task<TDestination>> func)
+        {
+            var result = await resultTask;
+            return await result.MapAsync(func);
+        }
+
+
+        public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(
+            this Task<Result<TSource>> resultTask,
+            Func<TSource, TDestination> func)
+        {
+            var result = await resultTask;
+            return result.Map(func);
+        }
+
+        public static async Task<Result<TDestination>> MapAsync<TDestination>(
+            this Task<Result> resultTask,
+            Func<TDestination> func)
+        {
+            var result = await resultTask;
+            return result.Map(func);
+        }
+
+        /// <summary>
+        /// Transforms a Result's type from a source type to a destination type.
+        /// If the Result is successful, the func parameter is invoked on the Result's source value to map it to a destination type.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the value contained in the source Result.</typeparam>
+        /// <typeparam name="TDestination">The type of the value to be returned in the destination Result.</typeparam>
+        /// <param name="result">The source Result to transform.</param>
+        /// <param name="func">A function to transform the source value to the destination type.</param>
+        /// <returns>A Result containing the transformed value or the appropriate error status.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the Result status is not supported.</exception>
+        public static Result<TDestination> Bind<TSource, TDestination>(this Result<TSource> result, Func<TSource, Result<TDestination>> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => bindFunc(result.Value),
+                ResultStatus.Created => bindFunc(result.Value),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+        public static Result<TDestination> Bind<TDestination>(this Result result, Func<Result, Result<TDestination>> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => bindFunc(result.Value),
+                ResultStatus.Created => bindFunc(result.Value),
+                _ => HandleNonSuccessStatus<TDestination>(result),
+            };
+        }
+
+        public static Result Bind<TSource>(this Result<TSource> result, Func<Result<TSource>, Result> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => bindFunc(result.Value),
+                ResultStatus.Created => bindFunc(result.Value),
+                _ => HandleNonSuccessStatus(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(
+            this Task<Result<TSource>> resultTask,
+            Func<TSource, Task<Result<TDestination>>> bindFunc)
+        {
+            var result = await resultTask;
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+        public static async Task<Result> BindAsync<TSource>(
+            this Task<Result<TSource>> resultTask,
+            Func<TSource, Task<Result>> bindFunc)
+        {
+            var result = await resultTask;
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus(result),
+            };
+        }
+
+        public static async Task<Result> BindAsync<TSource>(
+            this Result<TSource> result,
+            Func<TSource, Task<Result>> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus(result),
+            };
+        }
+
+        public static async Task<Result> BindAsync(
+            this Result result,
+            Func<Result, Task<Result>> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> BindAsync<TDestination>(
+            this Task<Result> resultTask,
+            Func<Result, Task<Result<TDestination>>> bindFunc)
+        {
+            var result = await resultTask;
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus<TDestination>(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(
+            this Result<TSource> result,
+            Func<TSource, Task<Result<TDestination>>> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+        public static async Task<Result> BindAsync<TSource, TDestination>(
+            this Result<TSource> result,
+            Func<TSource, Task<Result>> bindFunc)
+        {
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result.Value),
+                ResultStatus.Created => await bindFunc(result.Value),
+                _ => HandleNonSuccessStatus(result),
+            };
+        }
+
+        public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Result, Task<Result>> bindFunc)
+        {
+            var result = await resultTask;
+            return result.Status switch
+            {
+                ResultStatus.Ok => await bindFunc(result),
+                ResultStatus.Created => await bindFunc(result),
+                _ => HandleNonSuccessStatus(result),
+            };
+        }
+
+        public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(
+            this Task<Result<TSource>> resultTask,
+            Func<TSource, Result<TDestination>> bindFunc)
+        {
+            var result = await resultTask;
+            return result.Status switch
+            {
+                ResultStatus.Ok => bindFunc(result.Value),
+                ResultStatus.Created => bindFunc(result.Value),
+                _ => HandleNonSuccessStatus<TSource, TDestination>(result),
+            };
+        }
+
+        private static Result<TDestination> HandleNonSuccessStatus<TSource, TDestination>(Result<TSource> result)
+        {
+            return result.Status switch
+            {
+                ResultStatus.NotFound => result.Errors.Any()
+                    ? Result<TDestination>.NotFound(result.Errors.ToArray())
+                    : Result<TDestination>.NotFound(),
+                ResultStatus.Unauthorized => result.Errors.Any()
+                    ? Result<TDestination>.Unauthorized(result.Errors.ToArray())
+                    : Result<TDestination>.Unauthorized(),
+                ResultStatus.Forbidden => result.Errors.Any()
+                    ? Result<TDestination>.Forbidden(result.Errors.ToArray())
+                    : Result<TDestination>.Forbidden(),
+                ResultStatus.Invalid => Result<TDestination>.Invalid(result.ValidationErrors),
+                ResultStatus.Error => Result<TDestination>.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId)),
+                ResultStatus.Conflict => result.Errors.Any()
+                    ? Result<TDestination>.Conflict(result.Errors.ToArray())
+                    : Result<TDestination>.Conflict(),
+                ResultStatus.CriticalError => Result<TDestination>.CriticalError(result.Errors.ToArray()),
+                ResultStatus.Unavailable => Result<TDestination>.Unavailable(result.Errors.ToArray()),
+                ResultStatus.NoContent => Result<TDestination>.NoContent(),
+                _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
+            };
+        }
+
+        private static Result<TDestination> HandleNonSuccessStatus<TDestination>(Result result)
+        {
+            return result.Status switch
+            {
+                ResultStatus.NotFound => result.Errors.Any()
+                    ? Result<TDestination>.NotFound(result.Errors.ToArray())
+                    : Result<TDestination>.NotFound(),
+                ResultStatus.Unauthorized => result.Errors.Any()
+                    ? Result<TDestination>.Unauthorized(result.Errors.ToArray())
+                    : Result<TDestination>.Unauthorized(),
+                ResultStatus.Forbidden => result.Errors.Any()
+                    ? Result<TDestination>.Forbidden(result.Errors.ToArray())
+                    : Result<TDestination>.Forbidden(),
+                ResultStatus.Invalid => Result<TDestination>.Invalid(result.ValidationErrors),
+                ResultStatus.Error => Result<TDestination>.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId)),
+                ResultStatus.Conflict => result.Errors.Any()
+                    ? Result<TDestination>.Conflict(result.Errors.ToArray())
+                    : Result<TDestination>.Conflict(),
+                ResultStatus.CriticalError => Result<TDestination>.CriticalError(result.Errors.ToArray()),
+                ResultStatus.Unavailable => Result<TDestination>.Unavailable(result.Errors.ToArray()),
+                ResultStatus.NoContent => Result<TDestination>.NoContent(),
+                _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
+            };
+        }
+
+        private static Result HandleNonSuccessStatus<TSource>(Result<TSource> result)
+        {
+            return result.Status switch
+            {
+                ResultStatus.NotFound => result.Errors.Any()
+                    ? Result.NotFound(result.Errors.ToArray())
+                    : Result.NotFound(),
+                ResultStatus.Unauthorized => result.Errors.Any()
+                    ? Result.Unauthorized(result.Errors.ToArray())
+                    : Result.Unauthorized(),
+                ResultStatus.Forbidden => result.Errors.Any()
+                    ? Result.Forbidden(result.Errors.ToArray())
+                    : Result.Forbidden(),
+                ResultStatus.Invalid => Result.Invalid(result.ValidationErrors),
+                ResultStatus.Error => Result.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId)),
+                ResultStatus.Conflict => result.Errors.Any()
+                    ? Result.Conflict(result.Errors.ToArray())
+                    : Result.Conflict(),
+                ResultStatus.CriticalError => Result.CriticalError(result.Errors.ToArray()),
+                ResultStatus.Unavailable => Result.Unavailable(result.Errors.ToArray()),
+                ResultStatus.NoContent => Result.NoContent(),
+                _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
+            };
         }
     }
 }

--- a/tests/Ardalis.Result.UnitTests/ResultBind.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultBind.cs
@@ -1,0 +1,381 @@
+﻿using FluentAssertions;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Ardalis.Result.UnitTests
+{
+    public class ResultBind
+    {
+        [Fact]
+        public void ShouldProduceSuccessResultFromSuccess()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            var expected = Result<string>.Success(successValue.ToString());
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void CanChainSeveralMethods()
+        {
+            var result = Result<int>.Success(123);
+            var expected = Result<string>.Success("125");
+
+            var actual = result.Bind(v => Result<int>.Success(v + 1))
+                .Bind(v => Result<int>.Success(v + 1))
+                .Bind(v => Result<string>.Success(v.ToString()));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void CanChangeVoidResultToResult()
+        {
+            var result = Result.Success();
+            var expected = Result<string>.Success("Success");
+
+            var actual = result.Bind(_ => Result<string>.Success("Success"));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void CanBindResultToVoidResult()
+        {
+            var result = Result<int>.Success(123);
+            var expected = Result.Success();
+
+            var actual = result.Bind(_ => Result.Success());
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldProduceComplexTypeResultFromSuccessAnonymousFunction()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Success(foo);
+            var expected = Result<FooDto>.Success(new FooDto(foo.Bar));
+
+            var actual = result.Bind(foo => Result<FooDto>.Success(new FooDto(foo.Bar)));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldProduceComplexTypeResultFromSuccessWithMethod()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Success(foo);
+            var expected = Result<FooDto>.Success(FooDto.CreateFromFooResult(foo));
+
+            var actual = result.Bind(FooDto.CreateFromFooResult);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldProduceCreatedResultFromCreated()
+        {
+            int createdValue = 123;
+            var result = Result<int>.Created(createdValue);
+            var expected = Result<string>.Created(createdValue.ToString());
+
+            var actual = result.Bind(val => Result<string>.Created(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Created);
+            actual.Value.Should().Be(expected.Value);
+        }
+
+        [Fact]
+        public void ShouldProduceComplexTypeResultFromCreatedAnonymously()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Created(foo);
+            var expected = Result<FooDto>.Created(new FooDto(foo.Bar));
+
+            var actual = result.Bind(foo => Result<FooDto>.Created(new FooDto(foo.Bar)));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldProduceComplexTypeResultFromCreatedWithMethod()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Created(foo);
+            var expected = Result<FooDto>.Created(FooDto.CreateFromFooResult(foo));
+
+            var actual = result.Bind(FooDto.CreateFromFooCreatedResult);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldProduceNotFound()
+        {
+            var result = Result<int>.NotFound();
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.NotFound);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ShouldProduceNotFoundWithError()
+        {
+            string expectedMessage = "Some integer not found";
+            var result = Result<int>.NotFound(expectedMessage);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.NotFound);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldProduceUnauthorized()
+        {
+            var result = Result<int>.Unauthorized();
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Unauthorized);
+        }
+
+        [Fact]
+        public void ShouldProduceForbidden()
+        {
+            var result = Result<int>.Forbidden();
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public void ShouldProduceInvalidWithValidationErrors()
+        {
+            var validationErrors = new List<ValidationError>
+            {
+                new() { ErrorMessage = "Validation Error 1" },
+                new() { ErrorMessage = "Validation Error 2" }
+            };
+            var result = Result<int>.Invalid(validationErrors);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.ValidationErrors.Should().BeEquivalentTo(validationErrors);
+        }
+
+        [Fact]
+        public void ShouldProduceInvalidWithoutValidationErrors()
+        {
+            var validationErrors = new List<ValidationError>();
+            var result = Result<int>.Invalid(validationErrors);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.ValidationErrors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldProduceErrorResultWithErrors()
+        {
+            var errorList = new ErrorList(new[] { "Error 1", "Error 2" }, default);
+            var result = Result<int>.Error(errorList);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Should().BeEquivalentTo(errorList.ErrorMessages);
+        }
+
+        [Fact]
+        public void ShouldProduceErrorResultWithNoErrors()
+        {
+            var result = Result<int>.Error();
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Should().BeEmpty();
+            actual.CorrelationId.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldProduceConflict()
+        {
+            var result = Result<int>.Conflict();
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Conflict);
+        }
+
+        [Fact]
+        public void ShouldProduceConflictWithError()
+        {
+            string expectedMessage = "Some conflict";
+            var result = Result<int>.Conflict(expectedMessage);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Conflict);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldProduceUnavailableWithError()
+        {
+            string expectedMessage = "Something unavailable";
+            var result = Result<int>.Unavailable(expectedMessage);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Unavailable);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldProduceCriticalErrorWithError()
+        {
+            string expectedMessage = "Some critical error";
+            var result = Result<int>.CriticalError(expectedMessage);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.CriticalError);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldProduceForbiddenWithError()
+        {
+            string expectedMessage = "You are forbidden";
+            var result = Result<int>.Forbidden(expectedMessage);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Forbidden);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldProduceUnauthorizedWithError()
+        {
+            string expectedMessage = "You are unauthorized";
+            var result = Result<int>.Unauthorized(expectedMessage);
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.Unauthorized);
+            actual.Errors.Single().Should().Be(expectedMessage);
+        }
+
+        [Fact]
+        public void ShouldProduceNoContentWithoutAnyContent()
+        {
+            var result = Result<int>.NoContent();
+
+            var actual = result.Bind(val => Result<string>.Success(val.ToString()));
+
+            actual.Status.Should().Be(ResultStatus.NoContent);
+            actual.Value.Should().BeNull();
+            actual.Errors.Should().BeEmpty();
+            actual.ValidationErrors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ShouldPropagateErrorFromBindFunction()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            string expectedError = "Bind function failed";
+
+            var actual = result.Bind(val => Result<string>.Error(expectedError));
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(expectedError);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ShouldHandleNestedResultsInBind()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+
+            var actual = result.Bind(val =>
+            {
+                if (val > 1)
+                {
+                    return Result<string>.Success("Value is greater than 1");
+                }
+                else
+                {
+                    return Result<string>.Error("Value is less than or equal to 1");
+                }
+            });
+
+            actual.Status.Should().Be(ResultStatus.Ok);
+            actual.Value.Should().Be("Value is greater than 1");
+        }
+
+        [Fact]
+        public void ShouldHandleValidationErrorsFromBindFunction()
+        {
+            int successValue = 0;
+            var result = Result<int>.Success(successValue);
+            var validationErrors = new List<ValidationError>
+            {
+                new() { ErrorMessage = "Value must be greater than 1" }
+            };
+
+            var actual = result.Bind(val =>
+            {
+                if (val > 1)
+                {
+                    return Result<string>.Success("Valid value");
+                }
+                else
+                {
+                    return Result<string>.Invalid(validationErrors);
+                }
+            });
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.ValidationErrors.Should().BeEquivalentTo(validationErrors);
+            actual.Value.Should().BeNull();
+        }
+
+        private record Foo(string Bar);
+
+        private class FooDto
+        {
+            public string Bar { get; set; }
+
+            public FooDto(string bar)
+            {
+                Bar = bar;
+            }
+
+            public static Result<FooDto> CreateFromFooResult(Foo foo)
+            {
+                return Result<FooDto>.Success(new FooDto(foo.Bar));
+            }
+
+            public static Result<FooDto> CreateFromFooCreatedResult(Foo foo)
+            {
+                return Result<FooDto>.Created(new FooDto(foo.Bar));
+            }
+        }
+    }
+}

--- a/tests/Ardalis.Result.UnitTests/ResultBindAsync.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultBindAsync.cs
@@ -1,0 +1,802 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ardalis.Result.UnitTests
+{
+    public class ResultBindAsync
+    {
+        [Fact]
+        public async Task BindAsync_WithSuccessResultAndAsyncFunction_ReturnsSuccess()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            var expected = Result<string>.Success(successValue.ToString());
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithAsyncResultAndAsyncFunction_ReturnsSuccess()
+        {
+            int successValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(successValue));
+            var expected = Result<string>.Success(successValue.ToString());
+
+            var actual = await resultTask.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidAsyncResultToAsyncResult_ReturnsSuccess()
+        {
+            int successValue = 123;
+            var resultTask = Task.FromResult(Result.Success());
+            var expected = Result<int>.Success(successValue);
+
+            var actual = await resultTask.BindAsync(async _ =>
+            {
+                await Task.Delay(1);
+                return Result<int>.Success(successValue);
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidResultToAsyncResult_ReturnsSuccess()
+        {
+            int successValue = 123;
+            var result = Result.Success();
+            var expected = Result<int>.Success(successValue);
+
+            var actual = await result.BindAsync(async _ =>
+            {
+                await Task.Delay(1);
+                return Result<int>.Success(successValue);
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithAsyncResultAndSyncFunction_ReturnsSuccess()
+        {
+            int successValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(successValue));
+            var expected = Result<string>.Success(successValue.ToString());
+
+            var actual = await resultTask.BindAsync(val => Result<string>.Success(val.ToString()));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithComplexTypeAndAsyncFunction_ReturnsSuccess()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Success(foo);
+            var expected = Result<FooDto>.Success(new FooDto(foo.Bar));
+
+            var actual = await result.BindAsync(async fooValue =>
+            {
+                await Task.Delay(1);
+                return Result<FooDto>.Success(new FooDto(fooValue.Bar));
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithCreatedResultAndAsyncFunction_ReturnsCreated()
+        {
+            int createdValue = 123;
+            var result = Result<int>.Created(createdValue);
+            var expected = Result<string>.Created(createdValue.ToString());
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Created(val.ToString());
+            });
+
+            actual.Status.Should().Be(ResultStatus.Created);
+            actual.Value.Should().Be(expected.Value);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithNotFoundResult_PropagatesNotFound()
+        {
+            var result = Result<int>.NotFound();
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            actual.Status.Should().Be(ResultStatus.NotFound);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task BindAsync_WithErrorInBindFunction_PropagatesError()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            string expectedError = "Bind function failed";
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Error(expectedError);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(expectedError);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task BindAsync_WithValidationErrorsInBindFunction_ReturnsInvalid()
+        {
+            int successValue = 1;
+            var result = Result<int>.Success(successValue);
+            var validationErrors = new List<ValidationError>
+        {
+            new() { ErrorMessage = "Value must be greater than 1" }
+        };
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                if (val > 1)
+                {
+                    return Result<string>.Success("Valid value");
+                }
+                else
+                {
+                    return Result<string>.Invalid(validationErrors);
+                }
+            });
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.ValidationErrors.Should().BeEquivalentTo(validationErrors);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task BindAsync_WithUnauthorizedResult_PropagatesUnauthorized()
+        {
+            var result = Result<int>.Unauthorized();
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            actual.Status.Should().Be(ResultStatus.Unauthorized);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithForbiddenResult_PropagatesForbidden()
+        {
+            var result = Result<int>.Forbidden();
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            actual.Status.Should().Be(ResultStatus.Forbidden);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncResultWithErrorInBindFunction_ReturnsError()
+        {
+            var resultTask = Task.FromResult(Result<int>.Success(123));
+
+            var actual = await resultTask.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Error("Async error");
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be("Async error");
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncResultWithSyncBindFunction_ReturnsSuccess()
+        {
+            var resultTask = Task.FromResult(Result<int>.Success(123));
+            var expected = Result<string>.Success("123");
+
+            var actual = await resultTask.BindAsync(val => Result<string>.Success(val.ToString()));
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidAsyncResultToVoidAsyncResult_ReturnsSuccess()
+        {
+            Task<Result> resultTask = Task.FromResult(Result.Success());
+            Result expected = Result.Success();
+
+            var actual = await resultTask.BindAsync(async r =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidResultToAsyncResultWithValue_ReturnsSuccessWithValue()
+        {
+            int expectedValue = 123;
+            var result = Result.Success();
+
+            var actual = await result.BindAsync(async _ =>
+            {
+                await Task.Delay(1);
+                return Result<int>.Success(expectedValue);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Ok);
+            actual.Value.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncResultWithValueToVoidAsyncResult_ReturnsSuccess()
+        {
+            var resultTask = Task.FromResult(Result<int>.Success(123));
+
+            var actual = await resultTask.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncResultWithValueToVoidResult_ReturnsSuccess()
+        {
+            var resultTask = Task.FromResult(Result<int>.Success(123));
+
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidAsyncResultWithoutReturnValue_ReturnsSuccess()
+        {
+            var resultTask = Task.FromResult(Result.Success());
+
+            var actual = await resultTask.BindAsync(async _ =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithNoContentResult_PropagatesNoContent()
+        {
+            var result = Result<int>.NoContent();
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            actual.Status.Should().Be(ResultStatus.NoContent);
+            actual.Value.Should().BeNull();
+            actual.Errors.Should().BeEmpty();
+            actual.ValidationErrors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task BindAsync_DoesNotInvokeBindFunctionWhenResultIsError()
+        {
+            var result = Result<int>.Error("Initial error");
+
+            bool bindFunctionInvoked = false;
+
+            var actual = await result.BindAsync(async val =>
+            {
+                bindFunctionInvoked = true;
+                await Task.Delay(1);
+                return Result<string>.Success(val.ToString());
+            });
+
+            bindFunctionInvoked.Should().BeFalse();
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be("Initial error");
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncResultWithValueToVoidResultUsingSyncBindFunction_ReturnsSuccess()
+        {
+            int inputValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(inputValue));
+            var expected = Result.Success();
+
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithAsyncResultError_DoesNotInvokeBindFunction()
+        {
+            string errorMessage = "Initial error";
+            var resultTask = Task.FromResult(Result<int>.Error(errorMessage));
+
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_SyncBindFunctionReturnsError_ReturnsError()
+        {
+            int inputValue = 123;
+            string bindErrorMessage = "Error in bind function";
+            var resultTask = Task.FromResult(Result<int>.Success(inputValue));
+
+            var actual = await resultTask.BindAsync(val => Result.Error(bindErrorMessage));
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_SyncResultWithAsyncBindFunction_ReturnsSuccess()
+        {
+            int inputValue = 123;
+            var result = Result<int>.Success(inputValue);
+            var expected = Result.Success();
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithSyncResultError_DoesNotInvokeBindFunction()
+        {
+            string errorMessage = "Initial error";
+            var result = Result<int>.Error(errorMessage);
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncBindFunctionReturnsError_ReturnsError()
+        {
+            int inputValue = 123;
+            string bindErrorMessage = "Error in bind function";
+            var result = Result<int>.Success(inputValue);
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Error(bindErrorMessage);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidResultWithAsyncBindFunction_ReturnsSuccess()
+        {
+            var result = Result.Success();
+            var expected = Result.Success();
+
+            var actual = await result.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithVoidResultError_DoesNotInvokeBindFunction()
+        {
+            string errorMessage = "Initial error";
+            var result = Result.Error(errorMessage);
+
+            var actual = await result.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncBindFunctionReturnsErrorWithVoidResult_ReturnsError()
+        {
+            var result = Result.Success();
+            string bindErrorMessage = "Error in bind function";
+
+            var actual = await result.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Error(bindErrorMessage);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncVoidResultWithAsyncBindFunction_ReturnsSuccess()
+        {
+            var resultTask = Task.FromResult(Result.Success());
+            var expected = Result.Success();
+
+            var actual = await resultTask.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithAsyncVoidResultError_DoesNotInvokeBindFunction()
+        {
+            string errorMessage = "Initial error";
+            var resultTask = Task.FromResult(Result.Error(errorMessage));
+
+            var actual = await resultTask.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncBindFunctionReturnsErrorWithAsyncVoidResult_ReturnsError()
+        {
+            var resultTask = Task.FromResult(Result.Success());
+            string bindErrorMessage = "Error in bind function";
+
+            var actual = await resultTask.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Error(bindErrorMessage);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidAsyncResultWithAsyncBindFunction_ReturnsSuccess()
+        {
+            var resultTask = Task.FromResult(Result.Success());
+            var expected = Result.Success();
+
+            var actual = await resultTask.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithVoidAsyncResultError_DoesNotInvokeBindFunction()
+        {
+            var errorMessage = "Initial error";
+            var resultTask = Task.FromResult(Result.Error(errorMessage));
+
+            var actual = await resultTask.BindAsync(async res =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_SyncResultWithValueAndAsyncBindFunction_ReturnsSuccess()
+        {
+            int inputValue = 123;
+            var result = Result<int>.Success(inputValue);
+            var expected = Result.Success();
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_TaskResultTSourceWithSyncBindFunction_ReturnsSuccess()
+        {
+            // Arrange
+            Task<Result<int>> resultTask = Task.FromResult(Result<int>.Success(123));
+            var expected = Result.Success();
+
+            // Act
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            // Assert
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_VoidResultToTaskVoidResult_ReturnsSuccess()
+        {
+            // Arrange
+            var result = Result<int>.Success(123);
+            var expected = Result.Success();
+
+            // Act
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            // Assert
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithSyncResultWithValueError_DoesNotInvokeBindFunction()
+        {
+            var errorMessage = "Initial error";
+            var result = Result<int>.Error(errorMessage);
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncBindFunctionReturnsErrorOnResultWithValue_ReturnsError()
+        {
+            int inputValue = 123;
+            var result = Result<int>.Success(inputValue);
+            var bindErrorMessage = "Error in bind function";
+
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Error(bindErrorMessage);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_AsyncResultWithValueAndSyncBindFunction_ReturnsSuccess()
+        {
+            int inputValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(inputValue));
+            var expected = Result.Success();
+
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_WithAsyncResultWithValueError_DoesNotInvokeBindFunction()
+        {
+            var errorMessage = "Initial error";
+            var resultTask = Task.FromResult(Result<int>.Error(errorMessage));
+
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_SyncBindFunctionReturnsErrorOnAsyncResultWithValue_ReturnsError()
+        {
+            int inputValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(inputValue));
+            var bindErrorMessage = "Error in bind function";
+
+            var actual = await resultTask.BindAsync(val => Result.Error(bindErrorMessage));
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+
+        [Fact]
+        public async Task BindAsync_TaskResultTSourceWithSyncBindFunction_ReturnsError()
+        {
+            // Arrange
+            int successValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(successValue));
+            string bindErrorMessage = "Error in bind function";
+
+            // Act
+            var actual = await resultTask.BindAsync(val => Result.Error(bindErrorMessage));
+
+            // Assert
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_TaskResultTSourceError_DoesNotInvokeBindFunction()
+        {
+            // Arrange
+            string errorMessage = "Initial error";
+            var resultTask = Task.FromResult(Result<int>.Error(errorMessage));
+            bool bindFunctionInvoked = false;
+
+            // Act
+            var actual = await resultTask.BindAsync(val =>
+            {
+                bindFunctionInvoked = true;
+                return Result.Success();
+            });
+
+            // Assert
+            bindFunctionInvoked.Should().BeFalse();
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_TaskResultTSourceCreatedWithSyncBindFunction_ReturnsResult()
+        {
+            // Arrange
+            int createdValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Created(createdValue));
+
+            // Act
+            var actual = await resultTask.BindAsync(val => Result.Success());
+
+            // Assert
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task BindAsync_ResultTSourceWithAsyncBindFunction_ReturnsSuccess()
+        {
+            // Arrange
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            var expected = Result.Success();
+
+            // Act
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            // Assert
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task BindAsync_ResultTSourceWithAsyncBindFunction_ReturnsError()
+        {
+            // Arrange
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            string bindErrorMessage = "Error in bind function";
+
+            // Act
+            var actual = await result.BindAsync(async val =>
+            {
+                await Task.Delay(1);
+                return Result.Error(bindErrorMessage);
+            });
+
+            // Assert
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(bindErrorMessage);
+        }
+
+        [Fact]
+        public async Task BindAsync_ResultTSourceError_DoesNotInvokeBindFunction()
+        {
+            // Arrange
+            string errorMessage = "Initial error";
+            var result = Result<int>.Error(errorMessage);
+            bool bindFunctionInvoked = false;
+
+            // Act
+            var actual = await result.BindAsync(async val =>
+            {
+                bindFunctionInvoked = true;
+                await Task.Delay(1);
+                return Result.Success();
+            });
+
+            // Assert
+            bindFunctionInvoked.Should().BeFalse();
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be(errorMessage);
+        }
+
+        private record Foo(string Bar);
+
+        private class FooDto
+        {
+            public string Bar { get; set; }
+
+            public FooDto(string bar)
+            {
+                Bar = bar;
+            }
+
+            public static async Task<Result<FooDto>> CreateFromFooResultAsync(Foo foo)
+            {
+                await Task.Delay(1);
+                return Result<FooDto>.Success(new FooDto(foo.Bar));
+            }
+        }
+    }
+
+}

--- a/tests/Ardalis.Result.UnitTests/ResultMap.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultMap.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Ardalis.Result.UnitTests
@@ -235,7 +236,7 @@ namespace Ardalis.Result.UnitTests
         }
 
         [Fact]
-        public void ShouldProduceUnauthroizedWithError()
+        public void ShouldProduceUnauthorizedWithError()
         {
             string expectedMessage = "You are unauthorized";
             var result = Result<int>.Unauthorized(expectedMessage);

--- a/tests/Ardalis.Result.UnitTests/ResultMapAsync.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultMapAsync.cs
@@ -1,0 +1,210 @@
+﻿using FluentAssertions;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ardalis.Result.UnitTests
+{
+    public class ResultMapAsync
+    {
+        [Fact]
+        public async Task ShouldProduceReturnValueFromSuccessAsyncFunction()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+            string expected = successValue.ToString();
+
+            var actual = await result.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            expected.Should().BeEquivalentTo(actual.Value);
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task ShouldProduceReturnValueFromAsyncResultAndAsyncFunction()
+        {
+            int successValue = 123;
+            var resultTask = Task.FromResult(Result<int>.Success(successValue));
+            string expected = successValue.ToString();
+
+            var actual = await resultTask.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            expected.Should().BeEquivalentTo(actual.Value);
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task ShouldProduceComplexTypeReturnValueFromSuccessAsyncFunction()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Success(foo);
+
+            var actual = await result.MapAsync(async fooValue =>
+            {
+                await Task.Delay(1); 
+                return new FooDto(fooValue.Bar);
+            });
+
+            actual.Value.Bar.Should().Be(foo.Bar);
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task ShouldProduceReturnValueFromCreatedAsyncFunction()
+        {
+            int createdValue = 123;
+            var result = Result<int>.Created(createdValue);
+            string expected = createdValue.ToString();
+
+            var actual = await result.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            expected.Should().BeEquivalentTo(actual.Value);
+            actual.Status.Should().Be(ResultStatus.Created);
+        }
+
+        [Fact]
+        public async Task ShouldProduceNotFoundAsync()
+        {
+            var result = Result<int>.NotFound();
+
+            var actual = await result.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            actual.Status.Should().Be(ResultStatus.NotFound);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceErrorResultWithErrorsAsync()
+        {
+            var errorList = new ErrorList(["Error 1", "Error 2"], default);
+            var result = Result<int>.Error(errorList);
+
+            var actual = await result.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Should().BeEquivalentTo(errorList.ErrorMessages);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldHandleExceptionInMapFunctionAsync()
+        {
+            int successValue = 123;
+            var result = Result<int>.Success(successValue);
+
+            Func<Task> action = async () =>
+            {
+                await result.MapAsync<int, string>(async val =>
+                {
+                    await Task.Delay(1); 
+                    throw new InvalidOperationException("Test exception");
+                });
+            };
+
+            await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("Test exception");
+        }
+
+        [Fact]
+        public async Task ShouldNotInvokeMapFunctionWhenResultIsErrorAsync()
+        {
+            var result = Result<int>.Error("Initial error");
+
+            bool mapFunctionInvoked = false;
+
+            var actual = await result.MapAsync(async val =>
+            {
+                mapFunctionInvoked = true;
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            mapFunctionInvoked.Should().BeFalse();
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Errors.Single().Should().Be("Initial error");
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldPreserveLocationInCreatedStatusAsync()
+        {
+            var foo = new Foo("Bar");
+            var result = Result<Foo>.Created(foo, location: "/foo/1");
+
+            var actual = await result.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return new FooDto(val.Bar);
+            });
+
+            actual.Status.Should().Be(ResultStatus.Created);
+            actual.Value.Bar.Should().Be(foo.Bar);
+            actual.Location.Should().Be("/foo/1");
+        }
+
+        [Fact]
+        public async Task ShouldHandleAsyncResultAndAsyncMapFunctionWithErrorStatus()
+        {
+            var resultTask = Task.FromResult(Result<int>.NotFound("Item not found"));
+
+            var actual = await resultTask.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            actual.Status.Should().Be(ResultStatus.NotFound);
+            actual.Errors.Single().Should().Be("Item not found");
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceNoContentAsync()
+        {
+            var result = Result<int>.NoContent();
+
+            var actual = await result.MapAsync(async val =>
+            {
+                await Task.Delay(1); 
+                return val.ToString();
+            });
+
+            actual.Status.Should().Be(ResultStatus.NoContent);
+            actual.Value.Should().BeNull();
+            actual.Errors.Should().BeEmpty();
+            actual.ValidationErrors.Should().BeEmpty();
+        }
+
+        private record Foo(string Bar);
+
+        private class FooDto
+        {
+            public string Bar { get; set; }
+
+            public FooDto(string bar)
+            {
+                Bar = bar;
+            }
+        }
+    }
+}

--- a/tests/Ardalis.Result.UnitTests/ResultVoidMapAsync.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultVoidMapAsync.cs
@@ -1,0 +1,163 @@
+﻿using FluentAssertions;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ardalis.Result.UnitTests
+{
+    public class ResultVoidMapAsync
+    {
+        [Fact]
+        public async Task ShouldProduceSuccessWithValueGivenResultOfVoidAsync()
+        {
+            var result = Result.Success();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // Simulate async operation
+                return "Success";
+            });
+
+            actual.Value.Should().Be("Success");
+            actual.Status.Should().Be(ResultStatus.Ok);
+        }
+
+        [Fact]
+        public async Task ShouldProduceNotFoundAsync()
+        {
+            var result = Result.NotFound();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.NotFound);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceUnauthorizedAsync()
+        {
+            var result = Result.Unauthorized();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Unauthorized);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceForbiddenAsync()
+        {
+            var result = Result.Forbidden();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Forbidden);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceInvalidWithEmptyListAsync()
+        {
+            var result = Result.Invalid(new List<ValidationError>());
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.ValidationErrors.Should().BeEmpty();
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceInvalidAsync()
+        {
+            var validationError = new ValidationError { ErrorMessage = "Invalid input" };
+            var result = Result.Invalid(validationError);
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Invalid);
+            actual.ValidationErrors.Should().ContainSingle().Which.Should().BeEquivalentTo(validationError);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceErrorAsync()
+        {
+            var result = Result.Error();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Error);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceConflictAsync()
+        {
+            var result = Result.Conflict();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Conflict);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceUnavailableAsync()
+        {
+            var result = Result.Unavailable();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.Unavailable);
+            actual.Value.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ShouldProduceCriticalErrorAsync()
+        {
+            var result = Result.CriticalError();
+
+            var actual = await result.MapAsync(async _ =>
+            {
+                await Task.Delay(1); // This should not be called
+                return "This should be ignored";
+            });
+
+            actual.Status.Should().Be(ResultStatus.CriticalError);
+            actual.Value.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
This is related to https://github.com/ardalis/Result/issues/211


This is a PR that adds Bind in Addition to map to chain result producing functions. It also has overloads for async for all void result and task result types so no conversions should be needed. 
