### PR TITLE
Fixed bad overload. Bind should not take in a Func<Result>

### DIFF
--- a/src/Ardalis.Result/ResultExtensions.cs
+++ b/src/Ardalis.Result/ResultExtensions.cs
@@ -16,19 +16,25 @@ namespace Ardalis.Result
         /// <param name="func">A function to transform the source value to the destination type.</param>
         /// <returns>A Result containing the transformed value or the appropriate error status.</returns>
         /// <exception cref="NotSupportedException">Thrown when the Result status is not supported.</exception>
-        public static Result<TDestination> Map<TSource, TDestination>(this Result<TSource> result, Func<TSource, TDestination> func)
+        public static Result<TDestination> Map<TSource, TDestination>(
+            this Result<TSource> result,
+            Func<TSource, TDestination> func
+        )
         {
             return result.Status switch
             {
                 ResultStatus.Ok => (Result<TDestination>)func(result),
                 ResultStatus.Created => string.IsNullOrEmpty(result.Location)
-                                        ? Result<TDestination>.Created(func(result.Value))
-                                        : Result<TDestination>.Created(func(result.Value), result.Location),
+                    ? Result<TDestination>.Created(func(result.Value))
+                    : Result<TDestination>.Created(func(result.Value), result.Location),
                 _ => HandleNonSuccessStatus<TSource, TDestination>(result),
             };
         }
 
-        public static Result<TDestination> Map<TDestination>(this Result result, Func<TDestination> func)
+        public static Result<TDestination> Map<TDestination>(
+            this Result result,
+            Func<TDestination> func
+        )
         {
             return result.Status switch
             {
@@ -42,7 +48,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(
             this Result<TSource> result,
-            Func<TSource, Task<TDestination>> func)
+            Func<TSource, Task<TDestination>> func
+        )
         {
             return result.Status switch
             {
@@ -54,10 +61,10 @@ namespace Ardalis.Result
             };
         }
 
-      
         public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(
             this Task<Result<TSource>> resultTask,
-            Func<TSource, Task<TDestination>> func)
+            Func<TSource, Task<TDestination>> func
+        )
         {
             var result = await resultTask;
             return result.Status switch
@@ -72,7 +79,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> MapAsync<TDestination>(
             this Result result,
-            Func<Task<TDestination>> func)
+            Func<Task<TDestination>> func
+        )
         {
             return result.Status switch
             {
@@ -86,16 +94,17 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> MapAsync<TDestination>(
             this Task<Result> resultTask,
-            Func<Task<TDestination>> func)
+            Func<Task<TDestination>> func
+        )
         {
             var result = await resultTask;
             return await result.MapAsync(func);
         }
 
-
         public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(
             this Task<Result<TSource>> resultTask,
-            Func<TSource, TDestination> func)
+            Func<TSource, TDestination> func
+        )
         {
             var result = await resultTask;
             return result.Map(func);
@@ -103,7 +112,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> MapAsync<TDestination>(
             this Task<Result> resultTask,
-            Func<TDestination> func)
+            Func<TDestination> func
+        )
         {
             var result = await resultTask;
             return result.Map(func);
@@ -119,7 +129,10 @@ namespace Ardalis.Result
         /// <param name="func">A function to transform the source value to the destination type.</param>
         /// <returns>A Result containing the transformed value or the appropriate error status.</returns>
         /// <exception cref="NotSupportedException">Thrown when the Result status is not supported.</exception>
-        public static Result<TDestination> Bind<TSource, TDestination>(this Result<TSource> result, Func<TSource, Result<TDestination>> bindFunc)
+        public static Result<TDestination> Bind<TSource, TDestination>(
+            this Result<TSource> result,
+            Func<TSource, Result<TDestination>> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -129,7 +142,10 @@ namespace Ardalis.Result
             };
         }
 
-        public static Result<TDestination> Bind<TDestination>(this Result result, Func<Result, Result<TDestination>> bindFunc)
+        public static Result<TDestination> Bind<TDestination>(
+            this Result result,
+            Func<Result, Result<TDestination>> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -139,7 +155,10 @@ namespace Ardalis.Result
             };
         }
 
-        public static Result Bind<TSource>(this Result<TSource> result, Func<Result<TSource>, Result> bindFunc)
+        public static Result Bind<TSource>(
+            this Result<TSource> result,
+            Func<TSource, Result> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -151,7 +170,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(
             this Task<Result<TSource>> resultTask,
-            Func<TSource, Task<Result<TDestination>>> bindFunc)
+            Func<TSource, Task<Result<TDestination>>> bindFunc
+        )
         {
             var result = await resultTask;
             return result.Status switch
@@ -164,7 +184,8 @@ namespace Ardalis.Result
 
         public static async Task<Result> BindAsync<TSource>(
             this Task<Result<TSource>> resultTask,
-            Func<TSource, Task<Result>> bindFunc)
+            Func<TSource, Task<Result>> bindFunc
+        )
         {
             var result = await resultTask;
             return result.Status switch
@@ -177,7 +198,8 @@ namespace Ardalis.Result
 
         public static async Task<Result> BindAsync<TSource>(
             this Result<TSource> result,
-            Func<TSource, Task<Result>> bindFunc)
+            Func<TSource, Task<Result>> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -189,7 +211,8 @@ namespace Ardalis.Result
 
         public static async Task<Result> BindAsync(
             this Result result,
-            Func<Result, Task<Result>> bindFunc)
+            Func<Result, Task<Result>> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -201,7 +224,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> BindAsync<TDestination>(
             this Task<Result> resultTask,
-            Func<Result, Task<Result<TDestination>>> bindFunc)
+            Func<Result, Task<Result<TDestination>>> bindFunc
+        )
         {
             var result = await resultTask;
             return result.Status switch
@@ -214,7 +238,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(
             this Result<TSource> result,
-            Func<TSource, Task<Result<TDestination>>> bindFunc)
+            Func<TSource, Task<Result<TDestination>>> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -226,7 +251,8 @@ namespace Ardalis.Result
 
         public static async Task<Result> BindAsync<TSource, TDestination>(
             this Result<TSource> result,
-            Func<TSource, Task<Result>> bindFunc)
+            Func<TSource, Task<Result>> bindFunc
+        )
         {
             return result.Status switch
             {
@@ -236,7 +262,10 @@ namespace Ardalis.Result
             };
         }
 
-        public static async Task<Result> BindAsync(this Task<Result> resultTask, Func<Result, Task<Result>> bindFunc)
+        public static async Task<Result> BindAsync(
+            this Task<Result> resultTask,
+            Func<Result, Task<Result>> bindFunc
+        )
         {
             var result = await resultTask;
             return result.Status switch
@@ -249,7 +278,8 @@ namespace Ardalis.Result
 
         public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(
             this Task<Result<TSource>> resultTask,
-            Func<TSource, Result<TDestination>> bindFunc)
+            Func<TSource, Result<TDestination>> bindFunc
+        )
         {
             var result = await resultTask;
             return result.Status switch
@@ -260,7 +290,9 @@ namespace Ardalis.Result
             };
         }
 
-        private static Result<TDestination> HandleNonSuccessStatus<TSource, TDestination>(Result<TSource> result)
+        private static Result<TDestination> HandleNonSuccessStatus<TSource, TDestination>(
+            Result<TSource> result
+        )
         {
             return result.Status switch
             {
@@ -274,14 +306,22 @@ namespace Ardalis.Result
                     ? Result<TDestination>.Forbidden(result.Errors.ToArray())
                     : Result<TDestination>.Forbidden(),
                 ResultStatus.Invalid => Result<TDestination>.Invalid(result.ValidationErrors),
-                ResultStatus.Error => Result<TDestination>.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId)),
+                ResultStatus.Error => Result<TDestination>.Error(
+                    new ErrorList(result.Errors.ToArray(), result.CorrelationId)
+                ),
                 ResultStatus.Conflict => result.Errors.Any()
                     ? Result<TDestination>.Conflict(result.Errors.ToArray())
                     : Result<TDestination>.Conflict(),
-                ResultStatus.CriticalError => Result<TDestination>.CriticalError(result.Errors.ToArray()),
-                ResultStatus.Unavailable => Result<TDestination>.Unavailable(result.Errors.ToArray()),
+                ResultStatus.CriticalError => Result<TDestination>.CriticalError(
+                    result.Errors.ToArray()
+                ),
+                ResultStatus.Unavailable => Result<TDestination>.Unavailable(
+                    result.Errors.ToArray()
+                ),
                 ResultStatus.NoContent => Result<TDestination>.NoContent(),
-                _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
+                _ => throw new NotSupportedException(
+                    $"Result {result.Status} conversion is not supported."
+                ),
             };
         }
 
@@ -299,14 +339,22 @@ namespace Ardalis.Result
                     ? Result<TDestination>.Forbidden(result.Errors.ToArray())
                     : Result<TDestination>.Forbidden(),
                 ResultStatus.Invalid => Result<TDestination>.Invalid(result.ValidationErrors),
-                ResultStatus.Error => Result<TDestination>.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId)),
+                ResultStatus.Error => Result<TDestination>.Error(
+                    new ErrorList(result.Errors.ToArray(), result.CorrelationId)
+                ),
                 ResultStatus.Conflict => result.Errors.Any()
                     ? Result<TDestination>.Conflict(result.Errors.ToArray())
                     : Result<TDestination>.Conflict(),
-                ResultStatus.CriticalError => Result<TDestination>.CriticalError(result.Errors.ToArray()),
-                ResultStatus.Unavailable => Result<TDestination>.Unavailable(result.Errors.ToArray()),
+                ResultStatus.CriticalError => Result<TDestination>.CriticalError(
+                    result.Errors.ToArray()
+                ),
+                ResultStatus.Unavailable => Result<TDestination>.Unavailable(
+                    result.Errors.ToArray()
+                ),
                 ResultStatus.NoContent => Result<TDestination>.NoContent(),
-                _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
+                _ => throw new NotSupportedException(
+                    $"Result {result.Status} conversion is not supported."
+                ),
             };
         }
 
@@ -324,48 +372,66 @@ namespace Ardalis.Result
                     ? Result.Forbidden(result.Errors.ToArray())
                     : Result.Forbidden(),
                 ResultStatus.Invalid => Result.Invalid(result.ValidationErrors),
-                ResultStatus.Error => Result.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId)),
+                ResultStatus.Error => Result.Error(
+                    new ErrorList(result.Errors.ToArray(), result.CorrelationId)
+                ),
                 ResultStatus.Conflict => result.Errors.Any()
                     ? Result.Conflict(result.Errors.ToArray())
                     : Result.Conflict(),
                 ResultStatus.CriticalError => Result.CriticalError(result.Errors.ToArray()),
                 ResultStatus.Unavailable => Result.Unavailable(result.Errors.ToArray()),
                 ResultStatus.NoContent => Result.NoContent(),
-                _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
+                _ => throw new NotSupportedException(
+                    $"Result {result.Status} conversion is not supported."
+                ),
             };
         }
-        
+
         /// <summary>
         /// Transforms a Result's type from a source type to a non-generic Result type.
         /// </summary>
         /// <typeparam name="TSource"></typeparam>
         /// <param name="result"></param>
         /// <returns></returns>
-        /// <exception cref="NotSupportedException"></exception> 
+        /// <exception cref="NotSupportedException"></exception>
         public static Result Map<TSource>(this Result<TSource> result)
         {
             switch (result.Status)
             {
-                case ResultStatus.Ok: return Result.Success();
-                case ResultStatus.NotFound: return result.Errors.Any()
-                    ? Result.NotFound(result.Errors.ToArray())
-                    : Result.NotFound();
-                case ResultStatus.Unauthorized: return result.Errors.Any()
-                    ? Result.Unauthorized(result.Errors.ToArray())
-                    : Result.Unauthorized();
-                case ResultStatus.Forbidden: return result.Errors.Any()
-                    ? Result.Forbidden(result.Errors.ToArray())
-                    : Result.Forbidden();
-                case ResultStatus.Invalid: return Result.Invalid(result.ValidationErrors);
-                case ResultStatus.Error: return Result.Error(new ErrorList(result.Errors.ToArray(), result.CorrelationId));
-                case ResultStatus.Conflict: return result.Errors.Any()
-                    ? Result.Conflict(result.Errors.ToArray())
-                    : Result.Conflict();
-                case ResultStatus.CriticalError: return Result.CriticalError(result.Errors.ToArray());
-                case ResultStatus.Unavailable: return Result.Unavailable(result.Errors.ToArray());
-                case ResultStatus.NoContent: return Result.NoContent();
+                case ResultStatus.Ok:
+                    return Result.Success();
+                case ResultStatus.NotFound:
+                    return result.Errors.Any()
+                        ? Result.NotFound(result.Errors.ToArray())
+                        : Result.NotFound();
+                case ResultStatus.Unauthorized:
+                    return result.Errors.Any()
+                        ? Result.Unauthorized(result.Errors.ToArray())
+                        : Result.Unauthorized();
+                case ResultStatus.Forbidden:
+                    return result.Errors.Any()
+                        ? Result.Forbidden(result.Errors.ToArray())
+                        : Result.Forbidden();
+                case ResultStatus.Invalid:
+                    return Result.Invalid(result.ValidationErrors);
+                case ResultStatus.Error:
+                    return Result.Error(
+                        new ErrorList(result.Errors.ToArray(), result.CorrelationId)
+                    );
+                case ResultStatus.Conflict:
+                    return result.Errors.Any()
+                        ? Result.Conflict(result.Errors.ToArray())
+                        : Result.Conflict();
+                case ResultStatus.CriticalError:
+                    return Result.CriticalError(result.Errors.ToArray());
+                case ResultStatus.Unavailable:
+                    return Result.Unavailable(result.Errors.ToArray());
+                case ResultStatus.NoContent:
+                    return Result.NoContent();
                 default:
-                    throw new NotSupportedException($"Result {result.Status} conversion is not supported.");
+                    throw new NotSupportedException(
+                        $"Result {result.Status} conversion is not supported."
+                    );
             }
         }
     }

--- a/tests/Ardalis.Result.UnitTests/ResultBind.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultBind.cs
@@ -1,6 +1,6 @@
-﻿using FluentAssertions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 
 namespace Ardalis.Result.UnitTests
@@ -25,7 +25,8 @@ namespace Ardalis.Result.UnitTests
             var result = Result<int>.Success(123);
             var expected = Result<string>.Success("125");
 
-            var actual = result.Bind(v => Result<int>.Success(v + 1))
+            var actual = result
+                .Bind(v => Result<int>.Success(v + 1))
                 .Bind(v => Result<int>.Success(v + 1))
                 .Bind(v => Result<string>.Success(v.ToString()));
 
@@ -49,7 +50,7 @@ namespace Ardalis.Result.UnitTests
             var result = Result<int>.Success(123);
             var expected = Result.Success();
 
-            var actual = result.Bind(_ => Result.Success());
+            Result actual = result.Bind(_ => Result.Success());
 
             actual.Should().BeEquivalentTo(expected);
         }
@@ -164,7 +165,7 @@ namespace Ardalis.Result.UnitTests
             var validationErrors = new List<ValidationError>
             {
                 new() { ErrorMessage = "Validation Error 1" },
-                new() { ErrorMessage = "Validation Error 2" }
+                new() { ErrorMessage = "Validation Error 2" },
             };
             var result = Result<int>.Invalid(validationErrors);
 
@@ -336,7 +337,7 @@ namespace Ardalis.Result.UnitTests
             var result = Result<int>.Success(successValue);
             var validationErrors = new List<ValidationError>
             {
-                new() { ErrorMessage = "Value must be greater than 1" }
+                new() { ErrorMessage = "Value must be greater than 1" },
             };
 
             var actual = result.Bind(val =>


### PR DESCRIPTION
I erroneously added an overload to the bind method that takes in a Func<Result>. This confuses the compiler when trying to bind methods in a point free way. This is the only bind that needed to be fixed. 