### PR TITLE
Added ResultStatus.Accepted for HTTP 202 async processing support

### DIFF
--- a/src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs
@@ -75,6 +75,17 @@ namespace Ardalis.Result.AspNetCore
                         result.Location).Uri.AbsoluteUri;
 
                     return controller.Created(locationUri, result.GetValue());
+                case ResultStatus.Accepted:
+                    if(string.IsNullOrEmpty(result.Location))
+                        return controller.Accepted((string?)null, result.GetValue());
+                    
+                    var httpRequestAccepted = controller.HttpContext.Request;
+                    var locationUriAccepted = new UriBuilder(httpRequestAccepted.Scheme, 
+                        httpRequestAccepted.Host.Host, 
+                        httpRequestAccepted.Host.Port ?? -1,
+                        result.Location).Uri.AbsoluteUri;
+
+                    return controller.Accepted(locationUriAccepted, result.GetValue());
                 default:
                     return resultStatusOptions.ResponseType == null
                         ? (ActionResult)controller.StatusCode(statusCode)

--- a/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
@@ -29,7 +29,8 @@ public static partial class ResultExtensions
         result.Status switch
         {
             ResultStatus.Ok => result is Result ? Results.Ok() : Results.Ok(result.GetValue()),
-            ResultStatus.Created => Results.Created("", result.GetValue()),
+            ResultStatus.Created => Results.Created(result.Location ?? "", result.GetValue()),
+            ResultStatus.Accepted => Results.Accepted(result.Location ?? "", result.GetValue()),
             ResultStatus.NoContent => Results.NoContent(),
             ResultStatus.NotFound => NotFoundEntity(result),
             ResultStatus.Unauthorized => UnAuthorized(result),

--- a/src/Ardalis.Result.AspNetCore/ResultStatusMap.cs
+++ b/src/Ardalis.Result.AspNetCore/ResultStatusMap.cs
@@ -27,6 +27,7 @@ namespace Ardalis.Result.AspNetCore
 
             => For(ResultStatus.Ok, HttpStatusCode.OK)
                 .For(ResultStatus.Created, HttpStatusCode.Created)
+                .For(ResultStatus.Accepted, HttpStatusCode.Accepted)
                 .For(ResultStatus.Error, (HttpStatusCode)422, resultStatusOptions => resultStatusOptions
                     .With(UnprocessableEntity))
                 .For(ResultStatus.Forbidden, HttpStatusCode.Forbidden)

--- a/src/Ardalis.Result/IResultExtensions.cs
+++ b/src/Ardalis.Result/IResultExtensions.cs
@@ -13,6 +13,11 @@ public static class IResultExtensions
     public static bool IsCreated(this IResult result) => result.Status == ResultStatus.Created;
 
     /// <summary>
+    /// Returns true if the result is accepted (status is Accepted).
+    /// </summary>
+    public static bool IsAccepted(this IResult result) => result.Status == ResultStatus.Accepted;
+
+    /// <summary>
     /// Returns true if the result is an error (status is Error).
     /// </summary>
     public static bool IsError(this IResult result) => result.Status == ResultStatus.Error;

--- a/src/Ardalis.Result/Result.Void.cs
+++ b/src/Ardalis.Result/Result.Void.cs
@@ -61,6 +61,30 @@ namespace Ardalis.Result
 			return Result<T>.Created(value, location);
 		}
 
+		/// <summary>
+		/// Represents a successful operation where the request has been accepted for processing, but the processing has not been completed.
+		/// Accepts a value as the result of the operation.
+		/// </summary>		
+		/// <param name="value">Sets the Value property</param>
+		/// <returns>A Result<typeparamref name="T"/></returns>
+		public static Result<T> Accepted<T>(T value)
+		{
+			return Result<T>.Accepted(value);
+		}
+
+		/// <summary>
+		/// Represents a successful operation where the request has been accepted for processing, but the processing has not been completed.
+		/// Accepts a value as the result of the operation.
+		/// Accepts a location for monitoring the status.
+		/// </summary>		
+		/// <param name="value">Sets the Value property</param>
+		/// <param name="location">The location where the status of the operation can be monitored</param>
+		/// <returns>A Result<typeparamref name="T"/></returns>
+		public static Result<T> Accepted<T>(T value, string location)
+		{
+			return Result<T>.Accepted(value, location);
+		}
+
         /// <summary>
         /// Represents an error that occurred during the execution of the service.
         /// Error messages may be provided and will be exposed via the Errors property.

--- a/src/Ardalis.Result/Result.cs
+++ b/src/Ardalis.Result/Result.cs
@@ -35,7 +35,7 @@ namespace Ardalis.Result
         [JsonInclude]
         public ResultStatus Status { get; protected set; } = ResultStatus.Ok;
 
-        public bool IsSuccess => Status is ResultStatus.Ok or ResultStatus.NoContent or ResultStatus.Created;
+        public bool IsSuccess => Status is ResultStatus.Ok or ResultStatus.NoContent or ResultStatus.Created or ResultStatus.Accepted;
 
         [JsonInclude]
         public string SuccessMessage { get; protected set; } = string.Empty;
@@ -105,6 +105,23 @@ namespace Ardalis.Result
         /// <param name="location">The URL indicating where the newly created resource can be accessed.</param>
         /// <returns>A Result<typeparamref name="T"/> with status Created.</returns>
         public static Result<T> Created(T value, string location) => new(ResultStatus.Created) { Value = value, Location = location };
+
+        /// <summary>
+        /// Represents a successful operation where the request has been accepted for processing, but the processing has not been completed.
+        /// </summary>
+        /// <typeparam name="T">The type of the value returned.</typeparam>
+        /// <returns>A Result<typeparamref name="T"/> with status Accepted.</returns>
+        public static Result<T> Accepted(T value) => new(ResultStatus.Accepted) { Value = value };
+
+        /// <summary>
+        /// Represents a successful operation where the request has been accepted for processing, but the processing has not been completed.
+        /// Sets the Location property to the provided value.
+        /// </summary>
+        /// <typeparam name="T">The type of the value returned.</typeparam>
+        /// <param name="value">The value to return.</param>
+        /// <param name="location">The URL indicating where the status of the operation can be monitored.</param>
+        /// <returns>A Result<typeparamref name="T"/> with status Accepted.</returns>
+        public static Result<T> Accepted(T value, string location) => new(ResultStatus.Accepted) { Value = value, Location = location };
 
         /// <summary>
         /// Represents an error that occurred during the execution of the service.

--- a/src/Ardalis.Result/ResultStatus.cs
+++ b/src/Ardalis.Result/ResultStatus.cs
@@ -4,6 +4,7 @@
     {
         Ok,
         Created,
+        Accepted,
         Error,
         Forbidden,
         Unauthorized,

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
@@ -23,8 +23,8 @@ public class MinimalApiResultExtensionsCoverage : BaseResultConventionTest
         foreach (ResultStatus resultStatus in Enum.GetValues(typeof(ResultStatus)))
         {
 #if NET7_0
-            // Results.Created does not accept empty string URI in net7
-            if (resultStatus == ResultStatus.Created)
+            // Results.Created and Results.Accepted do not accept empty string URI in net7
+            if (resultStatus == ResultStatus.Created || resultStatus == ResultStatus.Accepted)
             {
                 continue;
             }

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMap.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMap.cs
@@ -18,7 +18,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(10, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -29,6 +29,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 
     [Fact]
@@ -43,7 +44,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(10, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -54,6 +55,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 
     [Fact]
@@ -83,7 +85,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(10, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -94,6 +96,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 
     [Theory]
@@ -110,7 +113,7 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
 
         convention.Apply(actionModel);
 
-        Assert.Equal(10, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(11, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 200, expectedType));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
@@ -122,5 +125,6 @@ public class ResultConventionDefaultResultStatusMap : BaseResultConventionTest
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 }

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMapModified.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMapModified.cs
@@ -21,7 +21,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(7, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -30,6 +30,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 
     [Fact]
@@ -46,7 +47,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(8, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -56,6 +57,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 409, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(void)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 
     [Theory]
@@ -80,7 +82,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(9, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(10, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, expectedStatusCode, expectedType));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 404, typeof(ProblemDetails)));
@@ -91,6 +93,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 
     [Theory]
@@ -114,7 +117,7 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
 
         convention.Apply(actionModel);
 
-        Assert.Equal(10, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
+        Assert.Equal(11, actionModel.Filters.Where(f => f is ProducesResponseTypeAttribute).Count());
 
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, expectedStatusCode, expectedType));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 204, typeof(void)));
@@ -126,5 +129,6 @@ public class ResultConventionDefaultResultStatusMapModified : BaseResultConventi
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 422, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 500, typeof(ProblemDetails)));
         Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 503, typeof(ProblemDetails)));
+        Assert.Contains(actionModel.Filters, f => ProducesResponseTypeAttribute(f, 202, typeof(void)));
     }
 }

--- a/tests/Ardalis.Result.UnitTests/IResultExtensions.cs
+++ b/tests/Ardalis.Result.UnitTests/IResultExtensions.cs
@@ -26,6 +26,17 @@ public class IResultExtensions
     }
 
     [Fact]
+    public void IsAccepted_ReturnsTrue_WhenStatusIsAccepted()
+    {
+        // Arrange & Act
+        var foo = new Foo("Bar");
+        var result = Result<Foo>.Accepted(foo);
+
+        // Assert
+        Assert.True(result.IsAccepted());
+    }
+
+    [Fact]
     public void IsError_ReturnsTrue_WhenStatusIsError()
     {
         // Arrange & Act

--- a/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
+++ b/tests/Ardalis.Result.UnitTests/ResultConstructor.cs
@@ -361,4 +361,47 @@ public class ResultConstructor
         
         Assert.True(result.IsSuccess);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(123)]
+    [InlineData("test value")]
+    public void InitializesStatusToAcceptedGivenAcceptedFactoryCall(object value)
+    {
+        var result = Result<object>.Accepted(value);
+
+        Assert.Equal(ResultStatus.Accepted, result.Status);
+        Assert.Equal(result.Location, string.Empty);
+        Assert.True(result.IsSuccess);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(123)]
+    [InlineData("test value")]
+    public void InitializesStatusToAcceptedAndSetLocationGivenAcceptedFactoryCall(object value)
+    {
+        string location = "status/12345";
+        var result = Result<object>.Accepted(value, location);
+
+        Assert.Equal(ResultStatus.Accepted, result.Status);
+        Assert.Equal(location, result.Location);
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public void InitializedIsSuccessTrueForAcceptedFactoryCall()
+    {
+        var result = Result<object>.Accepted(new object());
+        
+        Assert.True(result.IsSuccess);
+    }
+    
+    [Fact]
+    public void InitializedIsSuccessTrueForAcceptedWithLocationFactoryCall()
+    {
+        var result = Result<object>.Accepted(new object(), "status/endpoint");
+        
+        Assert.True(result.IsSuccess);
+    }
 }


### PR DESCRIPTION
This pull request adds support for the HTTP 202 Accepted status to the `Result` pattern, allowing APIs to indicate that a request has been accepted for processing but not yet completed. The changes include updates to the core `Result` model, extension methods, ASP.NET Core integration, and corresponding unit tests to ensure correct behavior and status mapping.

**Core Result Enhancements:**

* Added a new `ResultStatus.Accepted` value to the `ResultStatus` enum and updated the `IsSuccess` property to treat `Accepted` as a success status. (`src/Ardalis.Result/ResultStatus.cs` [[1]](diffhunk://#diff-5aff23451b25e6c0a281884ded5704f32f6130ce7c4a48b99acb69eeee80791aR7) `src/Ardalis.Result/Result.cs` [[2]](diffhunk://#diff-4281d684343631672c9a70451c3fd5cacdcf890c2aad95ac1759e13b64f03299L38-R38)
* Introduced static factory methods for creating `Accepted` results, both with and without a location value. (`src/Ardalis.Result/Result.cs` [[1]](diffhunk://#diff-4281d684343631672c9a70451c3fd5cacdcf890c2aad95ac1759e13b64f03299R109-R125) `src/Ardalis.Result/Result.Void.cs` [[2]](diffhunk://#diff-ac06d781986e7aaae485bfd5e692e5cf818f27f8d8e705998fe2c393ddda8186R64-R87)
* Added an `IsAccepted` extension method for checking if a result is accepted. (`src/Ardalis.Result/IResultExtensions.cs` [src/Ardalis.Result/IResultExtensions.csR15-R19](diffhunk://#diff-c53a21e8fe104d94e2ab92712abaf68f328a154c7a47e0de9b287982cc57f02eR15-R19))

**ASP.NET Core Integration:**

* Updated `ActionResultExtensions` and `MinimalApiResultExtensions` to handle `Accepted` results, including proper setting of the Location header when provided. (`src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs` [[1]](diffhunk://#diff-38aa13af0c5ba9deaa2b0361e762c08eddc125ade7f6a1369928ce0425d32845R78-R88) `src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs` [[2]](diffhunk://#diff-5e6302b9ee60d6b65eadf82e51d75b7d842967324d86bbfb5c51f745b51743abL32-R33)
* Mapped `ResultStatus.Accepted` to HTTP 202 in the default status map. (`src/Ardalis.Result.AspNetCore/ResultStatusMap.cs` [src/Ardalis.Result.AspNetCore/ResultStatusMap.csR30](diffhunk://#diff-3f438338c80fede0778c594f6fda6620d432c73871e3c8447810ea32a2ce9818R30))

**Testing and Validation:**

* Expanded and updated unit tests to cover the new `Accepted` status, ensuring correct status code mapping and response type attributes. (`tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMap.cs` [[1]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12L21-R21) [[2]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12R32) [[3]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12L46-R47) [[4]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12R58) [[5]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12L86-R88) [[6]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12R99) [[7]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12L113-R116) [[8]](diffhunk://#diff-e4ba7738f52c5ec7e9c1a3a58def0d7e34fa449d3b1ab26ba35a8774cc7ece12R128); `tests/Ardalis.Result.AspNetCore.UnitTests/ResultConventionDefaultResultStatusMapModified.cs` [[9]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaL24-R24) [[10]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaR33) [[11]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaL49-R50) [[12]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaR60) [[13]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaL83-R85) [[14]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaR96) [[15]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaL117-R120) [[16]](diffhunk://#diff-6cce5ba0ca0469066f4aa5d1ae99a5b05362b3057daf2bd577ebda6c47b770eaR132)
* Adjusted test coverage to ensure all code paths for the new status are exercised. (`tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs` [tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.csL26-R27](diffhunk://#diff-661d1178a9e5e522e86ea0de75f76b1fe6e9648806fbd5dbe09f07006474bbb1L26-R27))

These changes make it easier to build APIs that follow RESTful conventions for long-running or asynchronous operations by providing first-class support for the 202 Accepted status throughout the result handling pipeline.