### PR TITLE
Populate ProblemDetails.Status on error responses

### DIFF
--- a/src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/ActionResultExtensions.cs
@@ -76,9 +76,17 @@ namespace Ardalis.Result.AspNetCore
 
                     return controller.Created(locationUri, result.GetValue());
                 default:
-                    return resultStatusOptions.ResponseType == null
-                        ? (ActionResult)controller.StatusCode(statusCode)
-                        : controller.StatusCode(statusCode, resultStatusOptions.GetResponseObject(controller, result));
+                    if (resultStatusOptions.ResponseType == null)
+                        return controller.StatusCode(statusCode);
+
+                    var responseObject = resultStatusOptions.GetResponseObject(controller, result);
+
+                    // Populate ProblemDetails.Status to match the resolved HTTP status code (RFC 7807 section 3.1),
+                    // honoring any custom status-code mapping. Only set when unset to respect explicit values.
+                    if (responseObject is ProblemDetails problemDetails && problemDetails.Status is null)
+                        problemDetails.Status = statusCode;
+
+                    return controller.StatusCode(statusCode, responseObject);
             }
         }
     }

--- a/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
@@ -51,7 +51,8 @@ public static partial class ResultExtensions
         return Results.UnprocessableEntity(new ProblemDetails
         {
             Title = "Something went wrong.",
-            Detail = details.ToString()
+            Detail = details.ToString(),
+            Status = StatusCodes.Status422UnprocessableEntity
         });
     }
 
@@ -66,7 +67,8 @@ public static partial class ResultExtensions
             return Results.NotFound(new ProblemDetails
             {
                 Title = "Resource not found.",
-                Detail = details.ToString()
+                Detail = details.ToString(),
+                Status = StatusCodes.Status404NotFound
             });
         }
         else
@@ -86,7 +88,8 @@ public static partial class ResultExtensions
             return Results.Conflict(new ProblemDetails
             {
                 Title = "There was a conflict.",
-                Detail = details.ToString()
+                Detail = details.ToString(),
+                Status = StatusCodes.Status409Conflict
             });
         }
         else

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/ActionResultProblemDetailsStatusTests.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/ActionResultProblemDetailsStatusTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Xunit;
+
+namespace Ardalis.Result.AspNetCore.UnitTests;
+
+public class ActionResultProblemDetailsStatusTests
+{
+    [Fact]
+    public void ErrorPopulatesProblemDetailsStatus() => AssertProblemDetailsStatus(Result<int>.Error("boom"), 422);
+
+    [Fact]
+    public void NotFoundPopulatesProblemDetailsStatus() => AssertProblemDetailsStatus(Result<int>.NotFound("missing"), 404);
+
+    [Fact]
+    public void ConflictPopulatesProblemDetailsStatus() => AssertProblemDetailsStatus(Result<int>.Conflict("conflict"), 409);
+
+    [Fact]
+    public void CriticalErrorPopulatesProblemDetailsStatus() => AssertProblemDetailsStatus(Result<int>.CriticalError("boom"), 500);
+
+    [Fact]
+    public void UnavailablePopulatesProblemDetailsStatus() => AssertProblemDetailsStatus(Result<int>.Unavailable("down"), 503);
+
+    private static void AssertProblemDetailsStatus(Result<int> result, int expectedStatusCode)
+    {
+        var controller = new TestController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+                ActionDescriptor = new ControllerActionDescriptor()
+            }
+        };
+
+        var actionResult = controller.ToActionResult(result);
+
+        var objectResult = Assert.IsType<ObjectResult>(actionResult.Result);
+        var problemDetails = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal(expectedStatusCode, problemDetails.Status);
+        Assert.Equal(expectedStatusCode, objectResult.StatusCode);
+    }
+
+    private class TestController : ControllerBase;
+}

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
@@ -1,6 +1,9 @@
 #if NET6_0_OR_GREATER
 
+using System.Reflection;
+
 using Ardalis.Result.AspNetCore;
+using Microsoft.AspNetCore.Mvc;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -40,6 +43,50 @@ public class MinimalApiResultExtensionsCoverage : BaseResultConventionTest
                     $"Unhandled ResultStatus {resultStatus} in MinimalApiResultExtensions.ToMinimalApiResult: {e}");
             }
         }
+    }
+
+    [Fact]
+    public void ErrorResultPopulatesProblemDetailsStatus()
+    {
+        var problemDetails = ExtractProblemDetails(Result<int>.Error("boom").ToMinimalApiResult());
+        Assert.Equal(422, problemDetails.Status);
+    }
+
+    [Fact]
+    public void NotFoundResultWithErrorsPopulatesProblemDetailsStatus()
+    {
+        var problemDetails = ExtractProblemDetails(Result<int>.NotFound("missing").ToMinimalApiResult());
+        Assert.Equal(404, problemDetails.Status);
+    }
+
+    [Fact]
+    public void ConflictResultWithErrorsPopulatesProblemDetailsStatus()
+    {
+        var problemDetails = ExtractProblemDetails(Result<int>.Conflict("conflict").ToMinimalApiResult());
+        Assert.Equal(409, problemDetails.Status);
+    }
+
+    [Fact]
+    public void CriticalErrorResultStillPopulatesProblemDetailsStatus()
+    {
+        var problemDetails = ExtractProblemDetails(Result<int>.CriticalError("boom").ToMinimalApiResult());
+        Assert.Equal(500, problemDetails.Status);
+    }
+
+    // The concrete result type returned by Results.UnprocessableEntity/NotFound/Conflict/Problem differs across
+    // target frameworks (and is internal on net6), so read the ProblemDetails reflectively by well-known property name.
+    private static ProblemDetails ExtractProblemDetails(Microsoft.AspNetCore.Http.IResult result)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var type = result.GetType();
+        foreach (var propertyName in new[] { "ProblemDetails", "Value" })
+        {
+            if (type.GetProperty(propertyName, flags)?.GetValue(result) is ProblemDetails problemDetails)
+            {
+                return problemDetails;
+            }
+        }
+        throw new InvalidOperationException($"Could not extract ProblemDetails from {type.FullName}");
     }
 }
 #endif


### PR DESCRIPTION
Fixes #253.

`ProblemDetails` bodies were returned without `Status` set, so the body's `status` was `null` even though the HTTP status code was correct (and it was applied inconsistently — see #253 for the audit table). This populates it across both conversion paths:

- **Minimal API** (`MinimalApiResultExtensions`): added `Status` to the 422 / 404 / 409 builders (the three that omitted it).
- **MVC** (`ActionResultExtensions`): set `ProblemDetails.Status` from the *resolved* status code in `ToActionResult`, so it stays correct even when a consumer remaps status codes via `ResultStatusMap`, rather than hardcoding it in each builder.

**Non-breaking** — this only adds the `status` field to the response body; HTTP status codes are unchanged. Tested on net6.0 / net7.0 / net8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)