### PR TITLE
Make ToMinimalApiResult(IResult) overload public

### DIFF
--- a/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
+++ b/src/Ardalis.Result.AspNetCore/MinimalApiResultExtensions.cs
@@ -25,7 +25,13 @@ public static partial class ResultExtensions
     /// <returns></returns>
     public static Microsoft.AspNetCore.Http.IResult ToMinimalApiResult(this Result result) => ToMinimalApiResult((IResult)result);
 
-    internal static Microsoft.AspNetCore.Http.IResult ToMinimalApiResult(this IResult result) =>
+    /// <summary>
+    /// Convert an Ardalis.Result <see cref="IResult"/> to a <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+    /// Exposed so consumers can write a custom converter that handles selected statuses and delegates the
+    /// remaining statuses to the library's default mapping.
+    /// </summary>
+    /// <param name="result">The Ardalis.Result to convert.</param>
+    public static Microsoft.AspNetCore.Http.IResult ToMinimalApiResult(this IResult result) =>
         result.Status switch
         {
             ResultStatus.Ok => result is Result ? Results.Ok() : Results.Ok(result.GetValue()),

--- a/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
+++ b/tests/Ardalis.Result.AspNetCore.UnitTests/MinimalApiResultExtensionsCoverage.cs
@@ -41,5 +41,19 @@ public class MinimalApiResultExtensionsCoverage : BaseResultConventionTest
             }
         }
     }
+
+    [Fact]
+    public void IResultOverloadIsPubliclyCallableAndDelegatesToTypedOverload()
+    {
+        // Casting to the Ardalis.Result IResult interface and calling the (now public) overload directly
+        // must compile and behave the same as calling it on the concrete Result<T>.
+        Result<int> result = Result<int>.Success(42);
+        IResult asInterface = result;
+
+        Microsoft.AspNetCore.Http.IResult viaInterface = asInterface.ToMinimalApiResult();
+        Microsoft.AspNetCore.Http.IResult viaConcrete = result.ToMinimalApiResult();
+
+        Assert.Equal(viaConcrete.GetType(), viaInterface.GetType());
+    }
 }
 #endif


### PR DESCRIPTION
Addresses part of #244.

The `ToMinimalApiResult(this IResult)` overload was `internal`, so a consumer who wants to customize a *subset* of statuses has to reimplement the entire `switch`. Making it `public` lets a custom converter handle the cases it cares about and delegate the rest back to the library.

Pure visibility change + XML doc. Overload resolution is unaffected — concrete `Result` / `Result<T>` values still bind to their own overloads — so it is non-breaking. Tested on net6.0 / net7.0 / net8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)